### PR TITLE
Change Quest Condition execute params and add some more quest checks and execs

### DIFF
--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -15,6 +15,7 @@ import emu.grasscutter.game.dungeons.DungeonDropEntry;
 import emu.grasscutter.game.quest.QuestEncryptionKey;
 import emu.grasscutter.game.quest.RewindData;
 import emu.grasscutter.game.quest.TeleportData;
+import emu.grasscutter.game.quest.enums.QuestCond;
 import emu.grasscutter.utils.Utils;
 import emu.grasscutter.data.excels.*;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
@@ -27,6 +28,8 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import lombok.Getter;
 import lombok.experimental.Tolerate;
+
+import javax.annotation.Nullable;
 
 public class GameData {
     // BinOutputs
@@ -263,5 +266,10 @@ public class GameData {
 
     public static Int2ObjectMap<Route> getSceneRoutes(int sceneId) {
         return sceneRouteData.computeIfAbsent(sceneId, k -> new Int2ObjectOpenHashMap<>());
+    }
+
+    @Nullable
+    public static List<QuestData> getQuestDataByConditions(QuestCond questCond, int param0, String questStr){
+        return beginCondQuestMap.get(QuestData.questConditionKey(questCond, param0, questStr));
     }
 }

--- a/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
@@ -159,6 +159,7 @@ public class EntityMonster extends GameEntity {
 
         scene.getPlayers().forEach(p -> p.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_MONSTER_DIE, this.getMonsterId()));
         scene.getPlayers().forEach(p -> p.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_KILL_MONSTER, this.getMonsterId()));
+        scene.getPlayers().forEach(p -> p.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_CLEAR_GROUP_MONSTER, this.getGroupId()));
 
         scene.triggerDungeonEvent(DungeonPassConditionType.DUNGEON_COND_KILL_GROUP_MONSTER, this.getGroupId());
         scene.triggerDungeonEvent(DungeonPassConditionType.DUNGEON_COND_KILL_TYPE_MONSTER, this.getMonsterData().getType().getValue());

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -203,6 +203,7 @@ public class Player {
     @Getter private long playerGameTime = 0;
 
     @Getter private PlayerProgress playerProgress;
+    @Getter private Set<Integer> activeQuestTimers;
 
     @Deprecated
     @SuppressWarnings({"rawtypes", "unchecked"}) // Morphia only!
@@ -248,6 +249,7 @@ public class Player {
         this.unlockedScenePoints = new HashMap<>();
         this.chatEmojiIdList = new ArrayList<>();
         this.playerProgress = new PlayerProgress();
+        this.activeQuestTimers = new HashSet<>();
 
         this.attackResults = new LinkedBlockingQueue<>();
         this.coopRequests = new Int2ObjectOpenHashMap<>();
@@ -1192,6 +1194,9 @@ public class Player {
 
         // Recharge resin.
         this.getResinManager().rechargeResin();
+
+        // Quest tick handling
+        getQuestManager().onTick();
     }
 
     private synchronized void doDailyReset() {

--- a/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
@@ -56,7 +56,7 @@ public class PlayerProgress {
         }
 
         int addToObtainedCount(int amount){
-            this.obtainedCount+=obtainedCount;
+            this.obtainedCount+=amount;
             return this.obtainedCount;
         }
     }

--- a/src/main/java/emu/grasscutter/game/player/PlayerProgressManager.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgressManager.java
@@ -95,6 +95,8 @@ public class PlayerProgressManager extends BasePlayerDataManager {
         if (value != previousValue) {
             this.player.getOpenStates().put(openState, value);
 
+            this.player.getQuestManager().queueEvent(QuestCond.QUEST_COND_OPEN_STATE_EQUAL, openState, value);
+
             if (sendNotify) {
                 player.getSession().send(new PacketOpenStateChangeNotify(openState, value));
             }

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -60,7 +60,7 @@ public class GameMainQuest {
         this.talks = new HashMap<>();
         //official server always has a list of 5 questVars, with default value 0
         this.questVars = new int[] {0,0,0,0,0};
-        this.timeVar = new long[] {-1,-1,-1,-1,-1};
+        this.timeVar = new long[] {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1}; // theoretically max is 10 here
         this.state = ParentQuestState.PARENT_QUEST_STATE_NONE;
         this.questGroupSuites = new ArrayList<>();
         addAllChildQuests();
@@ -438,6 +438,7 @@ public class GameMainQuest {
             return false;
         }
         this.timeVar[index] = owner.getWorld().getWorldTimeSeconds();
+        owner.getActiveQuestTimers().add(this.parentQuestId);
         return true;
     }
 
@@ -447,7 +448,14 @@ public class GameMainQuest {
             return false;
         }
         this.timeVar[index] = -1;
+        if(!checkActiveTimers()){
+            owner.getActiveQuestTimers().remove(this.parentQuestId);
+        }
         return true;
+    }
+
+    public boolean checkActiveTimers(){
+        return Arrays.stream(timeVar).anyMatch(value -> value!=-1);
     }
 
     public long getDaysSinceTimeVar(int index){
@@ -461,7 +469,7 @@ public class GameMainQuest {
             return 0;
         }
 
-        return owner.getWorld().getGameTimeDays() - World.getDaysForGameTime(varTime);
+        return owner.getWorld().getTotalGameTimeDays() - World.getDaysForGameTime(varTime);
     }
 
     public long getHoursSinceTimeVar(int index){
@@ -475,6 +483,6 @@ public class GameMainQuest {
             return 0;
         }
 
-        return owner.getWorld().getGameTimeDays() - World.getHoursForGameTime(varTime);
+        return owner.getWorld().getTotalGameTimeDays() - World.getHoursForGameTime(varTime);
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -309,6 +309,7 @@ public class GameMainQuest {
                 .filter(p -> p.getState() == QuestState.QUEST_STATE_UNSTARTED || p.getState() == QuestState.UNFINISHED)
                 .filter(p -> p.getQuestData().getAcceptCond().stream().anyMatch(q -> condType == QuestCond.QUEST_COND_NONE || q.getType() == condType))
                 .toList();
+            val questSystem = owner.getServer().getQuestSystem();
 
             for (GameQuest subQuestWithCond : subQuestsWithCond) {
                 val acceptCond = subQuestWithCond.getQuestData().getAcceptCond();
@@ -316,7 +317,7 @@ public class GameMainQuest {
 
                 for (int i = 0; i < subQuestWithCond.getQuestData().getAcceptCond().size(); i++) {
                     val condition = acceptCond.get(i);
-                    boolean result = this.getOwner().getServer().getQuestSystem().triggerCondition(getOwner(), subQuestWithCond.getQuestData(), condition, paramStr, params);
+                    boolean result = questSystem.triggerCondition(getOwner(), subQuestWithCond.getQuestData(), condition, paramStr, params);
                     accept[i] = result ? 1 : 0;
                 }
 

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -313,7 +313,7 @@ public class GameMainQuest {
 
                 for (int i = 0; i < subQuestWithCond.getQuestData().getAcceptCond().size(); i++) {
                     val condition = acceptCond.get(i);
-                    boolean result = this.getOwner().getServer().getQuestSystem().triggerCondition(subQuestWithCond, condition, paramStr, params);
+                    boolean result = this.getOwner().getServer().getQuestSystem().triggerCondition(getOwner(), subQuestWithCond.getQuestData(), condition, paramStr, params);
                     accept[i] = result ? 1 : 0;
                 }
 

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -438,7 +438,7 @@ public class GameMainQuest {
             Grasscutter.getLogger().error("Trying to init out of bounds time var {} for quest {}", index, this.parentQuestId);
             return false;
         }
-        this.timeVar[index] = owner.getWorld().getWorldTimeSeconds();
+        this.timeVar[index] = owner.getWorld().getTotalGameTimeMinutes();
         owner.getActiveQuestTimers().add(this.parentQuestId);
         return true;
     }

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -68,7 +68,7 @@ public class GameQuest {
         clearProgress(false);
         this.acceptTime = Utils.getCurrentSeconds();
         this.startTime = this.acceptTime;
-        this.startGameDay = getOwner().getWorld().getGameTimeDays();
+        this.startGameDay = getOwner().getWorld().getTotalGameTimeDays();
         this.state = QuestState.QUEST_STATE_UNFINISHED;
         val triggerCond = questData.getFinishCond().stream()
             .filter(p -> p.getType() == QuestContent.QUEST_CONTENT_TRIGGER_FIRE).toList();

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -20,6 +20,7 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import lombok.Getter;
+import lombok.val;
 
 public class QuestManager extends BasePlayerManager {
 
@@ -108,6 +109,9 @@ public class QuestManager extends BasePlayerManager {
             }
             quest.checkProgress();
         }
+    }
+
+    public void onTick(){
     }
 
     private List<GameMainQuest> addMultMainQuests(Set<Integer> mainQuestIds) {
@@ -273,33 +277,8 @@ public class QuestManager extends BasePlayerManager {
         List<GameMainQuest> checkMainQuests = this.getMainQuests().values().stream()
             .filter(i -> i.getState() != ParentQuestState.PARENT_QUEST_STATE_FINISHED)
             .toList();
-        switch (condType) {
-            //accept Conds
-            case QUEST_COND_STATE_EQUAL:
-            case QUEST_COND_STATE_NOT_EQUAL:
-            case QUEST_COND_COMPLETE_TALK:
-            case QUEST_COND_LUA_NOTIFY:
-            case QUEST_COND_QUEST_VAR_EQUAL:
-            case QUEST_COND_QUEST_VAR_GREATER:
-            case QUEST_COND_QUEST_VAR_LESS:
-            case QUEST_COND_PLAYER_LEVEL_EQUAL_GREATER:
-            case QUEST_COND_QUEST_GLOBAL_VAR_EQUAL:
-            case QUEST_COND_QUEST_GLOBAL_VAR_GREATER:
-            case QUEST_COND_QUEST_GLOBAL_VAR_LESS:
-            case QUEST_COND_PACK_HAVE_ITEM:
-            case QUEST_COND_ITEM_NUM_LESS_THAN:
-            case QUEST_COND_ACTIVITY_OPEN:
-            case QUEST_COND_ACTIVITY_END:
-            case QUEST_COND_ACTIVITY_COND:
-                for (GameMainQuest mainquest : checkMainQuests) {
-                    mainquest.tryAcceptSubQuests(condType, paramStr, params);
-                }
-                break;
-
-            // unused
-            case QUEST_COND_PLAYER_CHOOSE_MALE:
-            default:
-                Grasscutter.getLogger().error("Unhandled QuestCondition {}", condType);
+        for (GameMainQuest mainquest : checkMainQuests) {
+            mainquest.tryAcceptSubQuests(condType, paramStr, params);
         }
     }
     public void triggerEvent(QuestContent condType, String paramStr, int... params) {
@@ -307,62 +286,9 @@ public class QuestManager extends BasePlayerManager {
         List<GameMainQuest> checkMainQuests = this.getMainQuests().values().stream()
             .filter(i -> i.getState() != ParentQuestState.PARENT_QUEST_STATE_FINISHED)
             .toList();
-        switch (condType) {
-            //fail Conds
-            case QUEST_CONTENT_NOT_FINISH_PLOT:
-            case QUEST_CONTENT_ANY_MANUAL_TRANSPORT:
-                for (GameMainQuest mainquest : checkMainQuests) {
-                    mainquest.tryFailSubQuests(condType, paramStr, params);
-                }
-                break;
-            //finish Conds
-            case QUEST_CONTENT_COMPLETE_TALK:
-            case QUEST_CONTENT_FINISH_PLOT:
-            case QUEST_CONTENT_COMPLETE_ANY_TALK:
-            case QUEST_CONTENT_QUEST_VAR_EQUAL:
-            case QUEST_CONTENT_QUEST_VAR_GREATER:
-            case QUEST_CONTENT_QUEST_VAR_LESS:
-            case QUEST_CONTENT_ENTER_DUNGEON:
-            case QUEST_CONTENT_ENTER_MY_WORLD_SCENE:
-            case QUEST_CONTENT_INTERACT_GADGET:
-            case QUEST_CONTENT_TRIGGER_FIRE:
-            case QUEST_CONTENT_UNLOCK_TRANS_POINT:
-            case QUEST_CONTENT_UNLOCK_AREA:
-            case QUEST_CONTENT_SKILL:
-            case QUEST_CONTENT_OBTAIN_ITEM:
-            case QUEST_CONTENT_MONSTER_DIE:
-            case QUEST_CONTENT_DESTROY_GADGET:
-            case QUEST_CONTENT_PLAYER_LEVEL_UP:
-            case QUEST_CONTENT_USE_ITEM:
-            case QUEST_CONTENT_ENTER_VEHICLE:
-            case QUEST_CONTENT_FINISH_DUNGEON:
-                for (GameMainQuest mainQuest : checkMainQuests) {
-                    mainQuest.tryFinishSubQuests(condType, paramStr, params);
-                }
-                break;
-
-            //finish Or Fail Conds
-            case QUEST_CONTENT_GAME_TIME_TICK:
-            case QUEST_CONTENT_QUEST_STATE_EQUAL:
-            case QUEST_CONTENT_ADD_QUEST_PROGRESS:
-            case QUEST_CONTENT_LEAVE_SCENE:
-            case QUEST_CONTENT_ITEM_LESS_THAN:
-            case QUEST_CONTENT_KILL_MONSTER:
-            case QUEST_CONTENT_LUA_NOTIFY:
-            case QUEST_CONTENT_ENTER_MY_WORLD:
-            case QUEST_CONTENT_ENTER_ROOM:
-            case QUEST_CONTENT_FAIL_DUNGEON:
-                for (GameMainQuest mainQuest : checkMainQuests) {
-                    mainQuest.tryFailSubQuests(condType, paramStr, params);
-                    mainQuest.tryFinishSubQuests(condType, paramStr, params);
-                }
-                break;
-
-            //Unused
-            case QUEST_CONTENT_QUEST_STATE_NOT_EQUAL:
-            case QUEST_CONTENT_WORKTOP_SELECT:
-            default:
-                Grasscutter.getLogger().error("Unhandled QuestTrigger {}", condType);
+        for (GameMainQuest mainQuest : checkMainQuests) {
+            mainQuest.tryFailSubQuests(condType, paramStr, params);
+            mainQuest.tryFinishSubQuests(condType, paramStr, params);
         }
     }
 

--- a/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
@@ -1,9 +1,11 @@
 package emu.grasscutter.game.quest;
 
 import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.data.excels.QuestData.QuestAcceptCondition;
 import emu.grasscutter.data.excels.QuestData.QuestContentCondition;
 import emu.grasscutter.data.excels.QuestData.QuestExecParam;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.conditions.BaseCondition;
 import emu.grasscutter.game.quest.content.BaseContent;
 import emu.grasscutter.game.quest.handlers.QuestExecHandler;
@@ -72,15 +74,15 @@ public class QuestSystem extends BaseGameSystem {
 
     // TODO make cleaner
 
-    public boolean triggerCondition(GameQuest quest, QuestAcceptCondition condition, String paramStr, int... params) {
+    public boolean triggerCondition(Player owner, QuestData questData, QuestAcceptCondition condition, String paramStr, int... params) {
         BaseCondition handler = condHandlers.get(condition.getType().getValue());
 
-        if (handler == null || quest.getQuestData() == null) {
-            Grasscutter.getLogger().debug("Could not trigger condition {} at {}", condition.getType().getValue(), quest.getQuestData());
+        if (handler == null || questData == null) {
+            Grasscutter.getLogger().debug("Could not trigger condition {} at {}", condition.getType().getValue(), questData);
             return false;
         }
 
-        return handler.execute(quest, condition, paramStr, params);
+        return handler.execute(owner, questData, condition, paramStr, params);
     }
 
     public boolean triggerContent(GameQuest quest, QuestContentCondition condition, String paramStr, int... params) {

--- a/src/main/java/emu/grasscutter/game/quest/conditions/BaseCondition.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/BaseCondition.java
@@ -1,19 +1,16 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
-import emu.grasscutter.game.quest.handlers.QuestBaseHandler;
 
-import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_NONE;
+import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_UNKNOWN;
 
-@QuestValueCond(QUEST_COND_NONE)
-public class BaseCondition extends QuestBaseHandler<QuestData.QuestAcceptCondition> {
+@QuestValueCond(QUEST_COND_UNKNOWN)
+public class BaseCondition {
 
-	@Override
-	public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-		// TODO Auto-generated method stub
-		return false;
-	}
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        return false;
+    }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/BaseConditionQuestVar.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/BaseConditionQuestVar.java
@@ -1,0 +1,40 @@
+package emu.grasscutter.game.quest.conditions;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.player.Player;
+import lombok.val;
+
+public abstract class BaseConditionQuestVar extends BaseCondition {
+
+    protected abstract boolean doCompare(int variable, int cond);
+
+    @Override
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val index = condition.getParam()[0];
+        val targetValue = condition.getParam()[1];
+        val questVarValue = getQuestVar(owner, questData, index);
+
+        Grasscutter.getLogger().debug("questVar {} : {}", index, questVarValue);
+
+        if (questVarValue < 0) {
+            return false;
+        }
+        return doCompare(questVarValue, targetValue);
+    }
+
+    protected int getQuestVar(Player owner, QuestData questData, int index) {
+        val mainQuest = owner.getQuestManager().getMainQuestById(questData.getMainId());
+        if (mainQuest == null) {
+            Grasscutter.getLogger().debug("mainQuest for quest var not available yet");
+            return -1;
+        }
+        val questVars = mainQuest.getQuestVars();
+        if (index >= questVars.length) {
+            Grasscutter.getLogger().error("questVar out of bounds for {} index {} size {}", questData.getSubId(), index, questVars.length);
+            return -2;
+        }
+        return questVars[index];
+    }
+
+}

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionActivityCond.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionActivityCond.java
@@ -1,8 +1,9 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_COND;
 
@@ -10,7 +11,10 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_CON
 public class ConditionActivityCond extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        return quest.getOwner().getActivityManager().meetsCondition(condition.getParam()[0]);
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val activityCondId = condition.getParam()[0];
+        val targetState = condition.getParam()[1]; // only 1 for now
+        return owner.getActivityManager().meetsCondition(activityCondId) == (targetState == 1);
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionActivityEnd.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionActivityEnd.java
@@ -1,8 +1,9 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_END;
 
@@ -10,8 +11,9 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_END
 public class ConditionActivityEnd extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        return quest.getOwner().getActivityManager().hasActivityEnded(condition.getParam()[0]);
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val activityId = condition.getParam()[0];
+        return owner.getActivityManager().hasActivityEnded(activityId);
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionCompleteTalk.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionCompleteTalk.java
@@ -3,7 +3,7 @@ package emu.grasscutter.game.quest.conditions;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
 import lombok.val;
 
@@ -13,9 +13,10 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_COMPLETE_TAL
 public class ConditionCompleteTalk extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
         val talkId = condition.getParam()[0];
-        val checkMainQuest = quest.getOwner().getQuestManager().getMainQuestByTalkId(talkId);
+        val unknownParam = condition.getParam()[1]; // e.g. 3 for 7081601
+        val checkMainQuest = owner.getQuestManager().getMainQuestByTalkId(talkId);
         if (checkMainQuest == null || GameData.getMainQuestDataMap().get(checkMainQuest.getParentQuestId()).getTalks() == null) {
             Grasscutter.getLogger().debug("Warning: mainQuest {} hasn't been started yet, or has no talks", talkId / 100);
             return false;

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionHistoryGotAnyItem.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionHistoryGotAnyItem.java
@@ -3,17 +3,16 @@ package emu.grasscutter.game.quest.conditions;
 import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import emu.grasscutter.game.quest.enums.QuestCond;
 import lombok.val;
 
-import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_OPEN;
-
-@QuestValueCond(QUEST_COND_ACTIVITY_OPEN)
-public class ConditionActivityOpen extends BaseCondition {
+@QuestValueCond(QuestCond.QUEST_COND_HISTORY_GOT_ANY_ITEM)
+public class ConditionHistoryGotAnyItem extends BaseCondition {
 
     @Override
     public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        val activityId = condition.getParam()[0];
-        return owner.getActivityManager().isActivityActive(activityId);
+        val itemId = condition.getParam()[0];
+        return owner.getPlayerProgress().hasPlayerObtainedItemHistorically(itemId);
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionIsDaytime.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionIsDaytime.java
@@ -1,0 +1,20 @@
+package emu.grasscutter.game.quest.conditions;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.QuestValueCond;
+import emu.grasscutter.game.quest.enums.QuestCond;
+import lombok.val;
+
+@QuestValueCond(QuestCond.QUEST_COND_IS_DAYTIME)
+public class ConditionIsDaytime extends BaseCondition{
+
+    @Override
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val daytime = condition.getParam()[0] == 1;
+        val currentTime = owner.getWorld().getGameTimeHours();
+        // TODO is this the real timeframe?
+        return (currentTime >=6 && currentTime<=18) == daytime;
+    }
+
+}

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionItemNumLessThan.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionItemNumLessThan.java
@@ -1,8 +1,9 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ITEM_NUM_LESS_THAN;
 
@@ -10,9 +11,11 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ITEM_NUM_LES
 public class ConditionItemNumLessThan extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        var checkItem = quest.getOwner().getInventory().getItemByGuid(condition.getParam()[0]);
-        return checkItem == null || checkItem.getCount() < condition.getParam()[1];
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val itemId = condition.getParam()[0];
+        val amount = condition.getParam()[1];
+        val checkItem = owner.getInventory().getItemByGuid(itemId);
+        return checkItem == null || checkItem.getCount() < amount;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionLuaNotify.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionLuaNotify.java
@@ -1,17 +1,20 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_LUA_NOTIFY;
 
 @QuestValueCond(QUEST_COND_LUA_NOTIFY)
 public class ConditionLuaNotify extends BaseCondition {
-    //Wrong implementation. Example: 7010226 has no paramStr
+
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        return condition.getParam()[0] == Integer.parseInt(paramStr);
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val triggerId = Integer.parseInt(paramStr);
+        val targetTrigger = condition.getParam()[0];
+        return targetTrigger == triggerId;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionNone.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionNone.java
@@ -3,17 +3,14 @@ package emu.grasscutter.game.quest.conditions;
 import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
-import lombok.val;
+import emu.grasscutter.game.quest.enums.QuestCond;
 
-import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_OPEN;
-
-@QuestValueCond(QUEST_COND_ACTIVITY_OPEN)
-public class ConditionActivityOpen extends BaseCondition {
+@QuestValueCond(QuestCond.QUEST_COND_NONE)
+public class ConditionNone extends BaseCondition{
 
     @Override
     public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        val activityId = condition.getParam()[0];
-        return owner.getActivityManager().isActivityActive(activityId);
+        return true;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionOpenStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionOpenStateEqual.java
@@ -3,17 +3,17 @@ package emu.grasscutter.game.quest.conditions;
 import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import emu.grasscutter.game.quest.enums.QuestCond;
 import lombok.val;
 
-import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_OPEN;
-
-@QuestValueCond(QUEST_COND_ACTIVITY_OPEN)
-public class ConditionActivityOpen extends BaseCondition {
+@QuestValueCond(QuestCond.QUEST_COND_OPEN_STATE_EQUAL)
+public class ConditionOpenStateEqual extends BaseCondition {
 
     @Override
     public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        val activityId = condition.getParam()[0];
-        return owner.getActivityManager().isActivityActive(activityId);
+        val openStateId = condition.getParam()[0];
+        val requiredState = condition.getParam()[1];
+        return owner.getProgressManager().getOpenState(openStateId) == requiredState;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPackHaveItem.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPackHaveItem.java
@@ -1,8 +1,9 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_PACK_HAVE_ITEM;
 
@@ -10,9 +11,11 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_PACK_HAVE_IT
 public class ConditionPackHaveItem extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        var checkItem = quest.getOwner().getInventory().getItemByGuid(condition.getParam()[0]);
-        return checkItem != null && checkItem.getCount() >= condition.getParam()[1];
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val itemId = condition.getParam()[0];
+        val targetAmount = condition.getParam()[1];
+        val checkItem = owner.getInventory().getItemByGuid(itemId);
+        return checkItem != null && checkItem.getCount() >= targetAmount;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPersonalLineUnlock.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPersonalLineUnlock.java
@@ -3,17 +3,16 @@ package emu.grasscutter.game.quest.conditions;
 import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import emu.grasscutter.game.quest.enums.QuestCond;
 import lombok.val;
 
-import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ACTIVITY_OPEN;
-
-@QuestValueCond(QUEST_COND_ACTIVITY_OPEN)
-public class ConditionActivityOpen extends BaseCondition {
+@QuestValueCond(QuestCond.QUEST_COND_PERSONAL_LINE_UNLOCK)
+public class ConditionPersonalLineUnlock extends BaseCondition {
 
     @Override
     public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        val activityId = condition.getParam()[0];
-        return owner.getActivityManager().isActivityActive(activityId);
+        val personalLineId = condition.getParam()[0];
+        return owner.getPersonalLineList().contains(personalLineId);
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPlayerLevelEqualGreater.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPlayerLevelEqualGreater.java
@@ -1,8 +1,9 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_PLAYER_LEVEL_EQUAL_GREATER;
 
@@ -10,8 +11,9 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_PLAYER_LEVEL
 public class ConditionPlayerLevelEqualGreater extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        return quest.getOwner().getLevel() >= condition.getParam()[0];
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val minLevel = condition.getParam()[0];
+        return owner.getLevel() >= minLevel;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestGlobalVarEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestGlobalVarEqual.java
@@ -2,8 +2,9 @@ package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_EQUAL;
 
@@ -11,9 +12,12 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_GLOBAL
 public class ConditionQuestGlobalVarEqual extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        Integer questGlobalVarValue = quest.getMainQuest().getQuestManager().getQuestGlobalVarValue(condition.getParam()[0]);
-        Grasscutter.getLogger().debug("questGlobarVar {} : {}", condition.getParam()[0], questGlobalVarValue);
-        return questGlobalVarValue == condition.getParam()[1];
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val questId = condition.getParam()[0];
+        val targetValue = condition.getParam()[1];
+        Integer questGlobalVarValue = owner.getQuestManager().getQuestGlobalVarValue(questId);
+        Grasscutter.getLogger().debug("questGlobarVar {} {} : {}", questId, targetValue, questGlobalVarValue);
+        return questGlobalVarValue == targetValue;
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestGlobalVarGreater.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestGlobalVarGreater.java
@@ -2,8 +2,9 @@ package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_GREATER;
 
@@ -11,9 +12,12 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_GLOBAL
 public class ConditionQuestGlobalVarGreater extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        Integer questGlobalVarValue = quest.getMainQuest().getQuestManager().getQuestGlobalVarValue(condition.getParam()[0]);
-        Grasscutter.getLogger().debug("questGlobarVar {} : {}", condition.getParam()[0], questGlobalVarValue);
-        return questGlobalVarValue > condition.getParam()[1];
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val questId = condition.getParam()[0];
+        val minValue = condition.getParam()[1];
+        Integer questGlobalVarValue = owner.getQuestManager().getQuestGlobalVarValue(questId);
+        Grasscutter.getLogger().debug("questGlobarVar {} {} : {}", questId, minValue, questGlobalVarValue);
+        return questGlobalVarValue > minValue;
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestGlobalVarLess.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestGlobalVarLess.java
@@ -2,8 +2,9 @@ package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_LESS;
 
@@ -11,9 +12,12 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_GLOBAL
 public class ConditionQuestGlobalVarLess extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        Integer questGlobalVarValue = quest.getMainQuest().getQuestManager().getQuestGlobalVarValue(condition.getParam()[0]);
-        Grasscutter.getLogger().debug("questGlobarVar {} : {}", condition.getParam()[0], questGlobalVarValue);
-        return questGlobalVarValue < condition.getParam()[1];
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val questId = condition.getParam()[0];
+        val maxValue = condition.getParam()[1];
+        Integer questGlobalVarValue = owner.getQuestManager().getQuestGlobalVarValue(questId);
+        Grasscutter.getLogger().debug("questGlobarVar {} {} : {}", questId, maxValue, questGlobalVarValue);
+        return questGlobalVarValue < maxValue;
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestVarEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestVarEqual.java
@@ -1,25 +1,15 @@
 package emu.grasscutter.game.quest.conditions;
 
-import emu.grasscutter.Grasscutter;
-import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueCond;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_VAR_EQUAL;
 
 @QuestValueCond(QUEST_COND_QUEST_VAR_EQUAL)
-public class ConditionQuestVarEqual extends BaseCondition {
+public class ConditionQuestVarEqual extends BaseConditionQuestVar {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        var index = condition.getParam()[0];
-        var questVars = quest.getMainQuest().getQuestVars();
-        if (index >= questVars.length) {
-            Grasscutter.getLogger().error("questVar out of bounds for {} index {} size {}", quest.getSubQuestId(), index, questVars.length);
-            return false;
-        }
-        int questVarValue = questVars[index];
-        Grasscutter.getLogger().debug("questVar {} : {}", index, questVarValue);
-        return questVarValue == condition.getParam()[1];
+    protected boolean doCompare(int variable, int cond) {
+        return variable == cond;
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestVarGreater.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestVarGreater.java
@@ -1,19 +1,15 @@
 package emu.grasscutter.game.quest.conditions;
 
-import emu.grasscutter.Grasscutter;
-import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueCond;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_VAR_GREATER;
 
 @QuestValueCond(QUEST_COND_QUEST_VAR_GREATER)
-public class ConditionQuestVarGreater extends BaseCondition {
+public class ConditionQuestVarGreater extends BaseConditionQuestVar {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        int questVarValue = quest.getMainQuest().getQuestVars()[condition.getParam()[0]];
-        Grasscutter.getLogger().debug("questVar {} : {}", condition.getParam()[0], questVarValue);
-        return questVarValue > condition.getParam()[1];
+    protected boolean doCompare(int variable, int cond) {
+        return variable > cond;
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestVarLess.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionQuestVarLess.java
@@ -1,19 +1,15 @@
 package emu.grasscutter.game.quest.conditions;
 
-import emu.grasscutter.Grasscutter;
-import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueCond;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_QUEST_VAR_LESS;
 
 @QuestValueCond(QUEST_COND_QUEST_VAR_LESS)
-public class ConditionQuestVarLess extends BaseCondition {
+public class ConditionQuestVarLess extends BaseConditionQuestVar {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        int questVarValue = quest.getMainQuest().getQuestVars()[condition.getParam()[0]];
-        Grasscutter.getLogger().debug("questVar {} : {}", condition.getParam()[0], questVarValue);
-        return questVarValue < condition.getParam()[1];
+    protected boolean doCompare(int variable, int cond) {
+        return variable < cond;
     }
+
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
@@ -1,8 +1,10 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_STATE_EQUAL;
 
@@ -10,17 +12,18 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_STATE_EQUAL;
 public class ConditionStateEqual extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(condition.getParam()[0]);
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val questId = condition.getParam()[0];
+        val questStateValue = condition.getParam()[0];
+        GameQuest checkQuest = owner.getQuestManager().getQuestById(questId);
         if (checkQuest == null) {
             /*
             Will spam the console
-            //Grasscutter.getLogger().debug("Warning: quest {} hasn't been started yet!", condition.getParam()[0]);
-
             */
+            //Grasscutter.getLogger().debug("Warning: quest {} hasn't been started yet!", condition.getParam()[0]);
             return false;
         }
-        return checkQuest.getState().getValue() == condition.getParam()[1];
+        return checkQuest.getState().getValue() == questStateValue;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
@@ -14,7 +14,7 @@ public class ConditionStateEqual extends BaseCondition {
     @Override
     public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
         val questId = condition.getParam()[0];
-        val questStateValue = condition.getParam()[0];
+        val questStateValue = condition.getParam()[1];
         GameQuest checkQuest = owner.getQuestManager().getQuestById(questId);
         if (checkQuest == null) {
             /*

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
@@ -14,7 +14,7 @@ public class ConditionStateNotEqual extends BaseCondition {
     @Override
     public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
         val questId = condition.getParam()[0];
-        val questStateValue = condition.getParam()[0];
+        val questStateValue = condition.getParam()[1];
         GameQuest checkQuest = owner.getQuestManager().getQuestById(questId);
         if (checkQuest == null) {
             /*

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
@@ -1,8 +1,10 @@
 package emu.grasscutter.game.quest.conditions;
 
 import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_STATE_NOT_EQUAL;
 
@@ -10,17 +12,19 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_STATE_NOT_EQ
 public class ConditionStateNotEqual extends BaseCondition {
 
     @Override
-    public boolean execute(GameQuest quest, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
-        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(condition.getParam()[0]);
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val questId = condition.getParam()[0];
+        val questStateValue = condition.getParam()[0];
+        GameQuest checkQuest = owner.getQuestManager().getQuestById(questId);
         if (checkQuest == null) {
             /*
             Will spam the console
+            */
             //Grasscutter.getLogger().debug("Warning: quest {} hasn't been started yet!", condition.getParam()[0]);
 
-            */
             return false;
         }
-        return checkQuest.getState().getValue() != condition.getParam()[1];
+        return checkQuest.getState().getValue() != questStateValue;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionTimeVarGreaterOrEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionTimeVarGreaterOrEqual.java
@@ -1,0 +1,25 @@
+package emu.grasscutter.game.quest.conditions;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.QuestValueCond;
+import emu.grasscutter.game.quest.enums.QuestCond;
+import lombok.val;
+
+@QuestValueCond(QuestCond.QUEST_COND_TIME_VAR_GT_EQ)
+public class ConditionTimeVarGreaterOrEqual extends BaseCondition{
+    @Override
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val mainQuestId = condition.getParam()[0];
+        val timeVarIndex = condition.getParam()[1];
+        val minTime = condition.getParam()[2];
+
+        val mainQuest = owner.getQuestManager().getMainQuestById(mainQuestId);
+
+        if(mainQuest == null){
+            return false;
+        }
+
+        return mainQuest.getHoursSinceTimeVar(timeVarIndex) >= minTime;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionTimeVarPassDay.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionTimeVarPassDay.java
@@ -1,0 +1,30 @@
+package emu.grasscutter.game.quest.conditions;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.QuestValueCond;
+import emu.grasscutter.game.quest.enums.QuestCond;
+import lombok.val;
+
+@QuestValueCond(QuestCond.QUEST_COND_TIME_VAR_PASS_DAY)
+public class ConditionTimeVarPassDay extends BaseCondition{
+    @Override
+    public boolean execute(Player owner, QuestData questData, QuestData.QuestAcceptCondition condition, String paramStr, int... params) {
+        val mainQuestId = condition.getParam()[0];
+        val timeVarIndex = condition.getParam()[1];
+        val minDays = condition.getParam()[2];
+
+        val mainQuest = owner.getQuestManager().getMainQuestById(mainQuestId);
+
+        if(mainQuest == null){
+            return false;
+        }
+
+        val daysSinceTimeVar = mainQuest.getDaysSinceTimeVar(timeVarIndex);
+        if(daysSinceTimeVar == -1){
+            return false;
+        }
+
+        return daysSinceTimeVar >= minDays;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentClearGroupMonster.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentClearGroupMonster.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.game.quest.content;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueContent;
+import emu.grasscutter.game.quest.enums.QuestContent;
+import lombok.val;
+
+@QuestValueContent(QuestContent.QUEST_CONTENT_CLEAR_GROUP_MONSTER)
+public class ContentClearGroupMonster extends BaseContent {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
+        val groupId = condition.getParam()[0];
+        return quest.getOwner().getScene().getScriptManager().hasClearedGroupMonsters(groupId);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentGameTimeTick.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentGameTimeTick.java
@@ -22,12 +22,16 @@ public class ContentGameTimeTick extends BaseContent {
 
         val daysToPass = condition.getParam()[0];
 
-        val isTimeMeet = from < to ? currentHour >= from && currentHour <= to
-            : currentHour <= to || currentHour >= from;
+        // if to is at the beginning of the day, we need to pass it one more time
+        val daysMod = to < from && daysToPass > 0 && currentHour < to ? 1 : 0;
 
-        val isDaysSinceMet =  daysSinceStart >= daysToPass;
+        val isTimeMet = from < to ? currentHour >= from && currentHour < to
+            : currentHour < to || currentHour >= from;
 
-        return isTimeMeet && isDaysSinceMet;
+        val isDaysSinceMet =  daysSinceStart >= daysToPass+daysMod;
+
+        return isTimeMet && isDaysSinceMet;
     }
 
 }
+

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentGameTimeTick.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentGameTimeTick.java
@@ -12,7 +12,7 @@ public class ContentGameTimeTick extends BaseContent {
 
     @Override
     public boolean execute(GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        val daysSinceStart = quest.getOwner().getWorld().getGameTimeDays() - quest.getStartGameDay();
+        val daysSinceStart = quest.getOwner().getWorld().getTotalGameTimeDays() - quest.getStartGameDay();
         val currentHour = quest.getOwner().getWorld().getGameTimeHours();
 
         // params[0] is days since start, str is hours of day

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarMoreOrEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarMoreOrEqual.java
@@ -1,0 +1,25 @@
+package emu.grasscutter.game.quest.content;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueContent;
+import emu.grasscutter.game.quest.enums.QuestContent;
+import lombok.val;
+
+@QuestValueContent(QuestContent.QUEST_CONTENT_TIME_VAR_GT_EQ)
+public class ContentTimeVarMoreOrEqual extends BaseContent{
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
+        val mainQuestId = condition.getParam()[0];
+        val timeVarIndex = condition.getParam()[1];
+        val minTime = Integer.parseInt(condition.getParamStr());
+
+        val mainQuest = quest.getOwner().getQuestManager().getMainQuestById(mainQuestId);
+
+        if(mainQuest == null){
+            return false;
+        }
+
+        return mainQuest.getHoursSinceTimeVar(timeVarIndex) >= minTime;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarPassDay.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarPassDay.java
@@ -1,0 +1,30 @@
+package emu.grasscutter.game.quest.content;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueContent;
+import emu.grasscutter.game.quest.enums.QuestContent;
+import lombok.val;
+
+@QuestValueContent(QuestContent.QUEST_CONTENT_TIME_VAR_PASS_DAY)
+public class ContentTimeVarPassDay extends BaseContent{
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
+        val mainQuestId = condition.getParam()[0];
+        val timeVarIndex = condition.getParam()[1];
+        val minDays = Integer.parseInt(condition.getParamStr());
+
+        val mainQuest = quest.getOwner().getQuestManager().getMainQuestById(mainQuestId);
+
+        if(mainQuest == null){
+            return false;
+        }
+
+        val daysSinceTimeVar = mainQuest.getDaysSinceTimeVar(timeVarIndex);
+        if(daysSinceTimeVar == -1){
+            return false;
+        }
+
+        return daysSinceTimeVar >= minDays;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
@@ -18,7 +18,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_CITY_LEVEL_EQUAL_GREATER (7), // missing, currently unused
     QUEST_COND_ITEM_NUM_LESS_THAN (8),
     QUEST_COND_DAILY_TASK_START (9), // missing
-    QUEST_COND_OPEN_STATE_EQUAL (10), // missing
+    QUEST_COND_OPEN_STATE_EQUAL (10),
     QUEST_COND_DAILY_TASK_OPEN (11), // missing, only NPC groups
     QUEST_COND_DAILY_TASK_REWARD_CAN_GET (12), // missing, only NPC groups/talks
     QUEST_COND_DAILY_TASK_REWARD_RECEIVED (13), // missing, only NPC groups/talks
@@ -55,7 +55,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_QUEST_GLOBAL_VAR_EQUAL (44),
     QUEST_COND_QUEST_GLOBAL_VAR_GREATER (45),
     QUEST_COND_QUEST_GLOBAL_VAR_LESS (46),
-    QUEST_COND_PERSONAL_LINE_UNLOCK (47), // missing
+    QUEST_COND_PERSONAL_LINE_UNLOCK (47),
     QUEST_COND_CITY_REPUTATION_REQUEST (48), // missing
     QUEST_COND_MAIN_COOP_START (49), // missing
     QUEST_COND_MAIN_COOP_ENTER_SAVE_POINT (50), // missing
@@ -77,7 +77,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_TIME_VAR_PASS_DAY (66), // missing
     QUEST_COND_HOMEWORLD_NPC_NEW_TALK (67), // missing, only NPC groups
     QUEST_COND_PLAYER_CHOOSE_MALE (68), // missing, only talks
-    QUEST_COND_HISTORY_GOT_ANY_ITEM (69), // missing
+    QUEST_COND_HISTORY_GOT_ANY_ITEM (69),
     QUEST_COND_LEARNED_RECIPE (70), // missing, currently unused
     QUEST_COND_LUNARITE_REGION_UNLOCKED (71), // missing, only NPC groups
     QUEST_COND_LUNARITE_HAS_REGION_HINT_COUNT (72), // missing, only NPC groups

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
@@ -29,7 +29,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_SCENE_AREA_UNLOCKED (18), // missing, only NPC groups/talks
     QUEST_COND_ITEM_GIVING_ACTIVED (19), // missing
     QUEST_COND_ITEM_GIVING_FINISHED (20), // missing
-    QUEST_COND_IS_DAYTIME (21), // missing, only NPC groups
+    QUEST_COND_IS_DAYTIME (21), // only NPC groups
     QUEST_COND_CURRENT_AVATAR (22), // missing
     QUEST_COND_CURRENT_AREA (23), // missing
     QUEST_COND_QUEST_VAR_EQUAL (24),
@@ -73,8 +73,8 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_NEW_HOMEWORLD_LEVEL_REWARD (62), // missing, only Gadget groups
     QUEST_COND_NEW_HOMEWORLD_MAKE_FINISH (63), // missing, only Gadget groups
     QUEST_COND_HOMEWORLD_NPC_EVENT (64), // missing, only NPC groups
-    QUEST_COND_TIME_VAR_GT_EQ (65), // missing, currently unused
-    QUEST_COND_TIME_VAR_PASS_DAY (66), // missing
+    QUEST_COND_TIME_VAR_GT_EQ (65), // currently unused
+    QUEST_COND_TIME_VAR_PASS_DAY (66),
     QUEST_COND_HOMEWORLD_NPC_NEW_TALK (67), // missing, only NPC groups
     QUEST_COND_PLAYER_CHOOSE_MALE (68), // missing, only talks
     QUEST_COND_HISTORY_GOT_ANY_ITEM (69),

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestContent.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestContent.java
@@ -15,7 +15,7 @@ public enum QuestContent implements QuestTrigger {
     QUEST_CONTENT_FINISH_PLOT (4),
     QUEST_CONTENT_OBTAIN_ITEM (5),
     QUEST_CONTENT_TRIGGER_FIRE (6),
-    QUEST_CONTENT_CLEAR_GROUP_MONSTER (7), // missing, finish
+    QUEST_CONTENT_CLEAR_GROUP_MONSTER (7),
     QUEST_CONTENT_NOT_FINISH_PLOT (8), // missing triggers, fail
     QUEST_CONTENT_ENTER_DUNGEON (9),
     QUEST_CONTENT_ENTER_MY_WORLD (10),
@@ -62,8 +62,8 @@ public enum QuestContent implements QuestTrigger {
     QUEST_CONTENT_MAIN_COOP_ENTER_ANY_SAVE_POINT (131),// missing, finish and fail
     QUEST_CONTENT_ENTER_MY_HOME_WORLD (132),// missing, finish and fail
     QUEST_CONTENT_ENTER_MY_WORLD_SCENE (133),// missing, finish
-    QUEST_CONTENT_TIME_VAR_GT_EQ (134),// missing, finish
-    QUEST_CONTENT_TIME_VAR_PASS_DAY (135),// missing, finish
+    QUEST_CONTENT_TIME_VAR_GT_EQ (134),
+    QUEST_CONTENT_TIME_VAR_PASS_DAY (135),
     QUEST_CONTENT_QUEST_STATE_EQUAL (136),
     QUEST_CONTENT_QUEST_STATE_NOT_EQUAL (137),
     QUEST_CONTENT_UNLOCKED_RECIPE (138),// missing, finish

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -65,8 +65,8 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_CHANGE_SKILL_DEPOT (55), // missing
     QUEST_EXEC_ADD_SCENE_TAG (56), // missing
     QUEST_EXEC_DEL_SCENE_TAG (57), // missing
-    QUEST_EXEC_INIT_TIME_VAR (58), // missing
-    QUEST_EXEC_CLEAR_TIME_VAR (59), // missing
+    QUEST_EXEC_INIT_TIME_VAR (58),
+    QUEST_EXEC_CLEAR_TIME_VAR (59),
     QUEST_EXEC_MODIFY_CLIMATE_AREA (60), // missing
     QUEST_EXEC_GRANT_TRIAL_AVATAR_AND_LOCK_TEAM (61), // missing
     QUEST_EXEC_CHANGE_MAP_AREA_STATE (62), // missing

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecClearTimeVar.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecClearTimeVar.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import lombok.val;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_CLEAR_TIME_VAR)
+public class ExecClearTimeVar extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        val timeVarId = Integer.parseInt(condition.getParam()[0]);
+        val mainQuest = quest.getMainQuest();
+        return mainQuest.clearTimeVar(timeVarId);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecClearTimeVar.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecClearTimeVar.java
@@ -11,8 +11,9 @@ import lombok.val;
 public class ExecClearTimeVar extends QuestExecHandler {
     @Override
     public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
-        val timeVarId = Integer.parseInt(condition.getParam()[0]);
-        val mainQuest = quest.getMainQuest();
+        val mainQuestId = Integer.parseInt(condition.getParam()[0]);
+        val timeVarId = Integer.parseInt(condition.getParam()[1]);
+        val mainQuest = quest.getOwner().getQuestManager().getMainQuestById(mainQuestId);
         return mainQuest.clearTimeVar(timeVarId);
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecInitTimeVar.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecInitTimeVar.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import lombok.val;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_INIT_TIME_VAR)
+public class ExecInitTimeVar extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        val timeVarId = Integer.parseInt(condition.getParam()[0]);
+        val mainQuest = quest.getMainQuest();
+        return mainQuest.initTimeVar(timeVarId);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -418,7 +418,15 @@ public class World implements Iterable<Player> {
     }
 
     public long getGameTimeDays() {
-        return getWorldTimeSeconds() / 1440 ;
+        return getDaysForGameTime(getWorldTimeSeconds());
+    }
+
+    public static long getDaysForGameTime(long time){
+        return time / 1440;
+    }
+
+    public static long getHoursForGameTime(long time){
+        return time / 60;
     }
 
     public void setPaused(boolean paused) {

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -374,11 +374,6 @@ public class World implements Iterable<Player> {
         if (this.getPlayerCount() == 0) return true;
         this.scenes.forEach((k, scene) -> scene.onTick());
 
-        // trigger game time tick for quests TODO maybe move it to onTick for QuestManager?
-        players.forEach(p -> p.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_GAME_TIME_TICK,
-            getGameTimeHours() , // hours
-            0)); //days
-
 
         // sync time every 10 seconds
         if(tickCount%10 == 0){
@@ -417,8 +412,12 @@ public class World implements Iterable<Player> {
         return getGameTime() / 60 ;
     }
 
-    public long getGameTimeDays() {
+    public long getTotalGameTimeDays() {
         return getDaysForGameTime(getWorldTimeSeconds());
+    }
+
+    public long getTotalGameTimeHours() {
+        return getHoursForGameTime(getWorldTimeSeconds());
     }
 
     public static long getDaysForGameTime(long time){

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -404,30 +404,6 @@ public class World implements Iterable<Player> {
             days)); //days
     }
 
-    public int getGameTime() {
-        return (int)(getWorldTimeSeconds() % 1440);
-    }
-
-    public int getGameTimeHours() {
-        return getGameTime() / 60 ;
-    }
-
-    public long getTotalGameTimeDays() {
-        return getDaysForGameTime(getWorldTimeSeconds());
-    }
-
-    public long getTotalGameTimeHours() {
-        return getHoursForGameTime(getWorldTimeSeconds());
-    }
-
-    public static long getDaysForGameTime(long time){
-        return time / 1440;
-    }
-
-    public static long getHoursForGameTime(long time){
-        return time / 60;
-    }
-
     public void setPaused(boolean paused) {
         getWorldTime();
         if(this.isPaused != paused && !paused){
@@ -438,6 +414,52 @@ public class World implements Iterable<Player> {
         scenes.forEach((key, scene) -> scene.setPaused(paused));
     }
 
+    public static long getDaysForGameTime(long inGameMinutes){
+        return inGameMinutes / 1440;
+    }
+
+    public static long getHoursForGameTime(long inGameMinutes){
+        return inGameMinutes / 60;
+    }
+
+    /**
+     * Returns the current in game days world time in ingame minutes (0-1439)
+     */
+    public int getGameTime() {
+        return (int)(getTotalGameTimeMinutes() % 1440);
+    }
+
+    /**
+     * Returns the current in game days world time in ingame hours (0-23)
+     */
+    public int getGameTimeHours() {
+        return getGameTime() / 60 ;
+    }
+
+    /**
+     * Returns the total number of in game days that got completed since the beginning of the game
+     */
+    public long getTotalGameTimeDays() {
+        return getDaysForGameTime(getTotalGameTimeMinutes());
+    }
+
+    /**
+     * Returns the total number of in game hours that got completed since the beginning of the game
+     */
+    public long getTotalGameTimeHours() {
+        return getHoursForGameTime(getTotalGameTimeMinutes());
+    }
+
+    /**
+     * Returns the total amount of ingame minutes that got completed since the beginning of the game
+     */
+    public long getTotalGameTimeMinutes() {
+        return getWorldTime()/1000;
+    }
+
+    /**
+     * Returns the ingame world time in irl millis
+     */
     public long getWorldTime() {
         if(!isPaused) {
             long newUpdateTime = System.currentTimeMillis();
@@ -445,10 +467,6 @@ public class World implements Iterable<Player> {
             this.lastUpdateTime = newUpdateTime;
         }
         return currentWorldTime;
-    }
-
-    public long getWorldTimeSeconds() {
-        return getWorldTime()/1000;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -647,4 +647,18 @@ public class SceneScriptManager {
         return 1;
     }
 
+    // todo implement properly with proper group loading
+    public boolean hasClearedGroupMonsters(int groupId){
+        val group = getGroupById(groupId);
+        if(group == null || !group.isLoaded() || group.monsters == null){
+            return false;
+        }
+        for(val monster : group.monsters.values()) {
+            if(scene.getEntityByConfigId(monster.config_id, groupId) !=null){
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerAddQuestContentProgressReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerAddQuestContentProgressReq.java
@@ -1,34 +1,25 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.data.GameData;
-import emu.grasscutter.data.excels.QuestData;
-import emu.grasscutter.game.quest.enums.QuestCond;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AddQuestContentProgressReqOuterClass;
+import emu.grasscutter.net.proto.AddQuestContentProgressReqOuterClass.AddQuestContentProgressReq;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketAddQuestContentProgressRsp;
-import java.util.List;
-import java.util.stream.Stream;
+import lombok.val;
+
 
 @Opcodes(PacketOpcodes.AddQuestContentProgressReq)
 public class HandlerAddQuestContentProgressReq extends PacketHandler {
 
     @Override
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        var req = AddQuestContentProgressReqOuterClass.AddQuestContentProgressReq.parseFrom(payload);
+        var req = AddQuestContentProgressReq.parseFrom(payload);
         //Find all conditions in quest that are the same as the given one
-        Stream<QuestData.QuestAcceptCondition> acceptCond = GameData.getQuestDataMap().get(req.getParam()).getAcceptCond().stream();
-        Stream<QuestData.QuestContentCondition> finishCond = GameData.getQuestDataMap().get(req.getParam()).getFinishCond().stream();
-        Stream<QuestData.QuestContentCondition> failCond = GameData.getQuestDataMap().get(req.getParam()).getFailCond().stream();
-        List<QuestData.QuestContentCondition> allCondMatch = Stream.concat(failCond,finishCond).filter(p -> p.getType().getValue() == req.getContentType()).toList();
-        for (QuestData.QuestContentCondition cond : allCondMatch ) {
-            session.getPlayer().getQuestManager().queueEvent(QuestContent.getContentTriggerByValue(req.getContentType()), cond.getParam());
-        }
-        for (QuestData.QuestAcceptCondition cond : acceptCond.toList() ) {
-            session.getPlayer().getQuestManager().queueEvent(QuestCond.getContentTriggerByValue(req.getContentType()), cond.getParam());
+        val type = QuestContent.getContentTriggerByValue(req.getContentType());
+        if(type!=null) {
+            session.getPlayer().getQuestManager().queueEvent(type, req.getParam());
         }
         session.send(new PacketAddQuestContentProgressRsp(req.getContentType()));
     }


### PR DESCRIPTION
make QuestConditions checks Quest object independend to allow prepare for better accept condition handling

Added Quest conditions, Content and execs
* QUEST_COND_HISTORY_GOT_ANY_ITEM
* QUEST_COND_OPEN_STATE_EQUAL
* QUEST_COND_PERSONAL_LINE_UNLOCK
* QUEST_COND_IS_DAYTIME (unused)
* QUEST_COND_TIME_VAR_GT_EQ (unused)
* QUEST_COND_TIME_VAR_PASS_DAY
* QUEST_CONTENT_TIME_VAR_GT_EQ
* QUEST_CONTENT_TIME_VAR_PASS_DAY
* QUEST_CONTENT_CLEAR_GROUP_MONSTER (needs propper implementation for the check with new group management)
* QUEST_EXEC_INIT_TIME_VAR
* QUEST_EXEC_CLEAR_TIME_VAR