### PR TITLE
Add group loading based on pos to mimic the original behaviour

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -388,20 +388,37 @@ public class SceneScriptManager {
             List<Map<GridPosition, Set<Integer>>> groupPositions = new ArrayList<>();
             for(int i = 0; i < 6; i++) groupPositions.add(new HashMap<>());
 
+            var visionOptions = Grasscutter.getConfig().server.game.visionOptions;
             meta.blocks.values().forEach(block -> {
                 block.load(scene.getId(), meta.context);
                 block.groups.values().stream().filter(g -> !g.dynamic_load).forEach(group -> {
                     group.load(this.scene.getId());
 
                     //Add all entitites here
-                    group.monsters.values().forEach(m -> addGridPositionToMap(groupPositions.get(m.vision_level), group.id, m.vision_level, m.pos));
+                    Set<Integer> vision_levels = new HashSet<>();
+                    group.monsters.values().forEach(m -> {
+                        addGridPositionToMap(groupPositions.get(m.vision_level), group.id, m.vision_level, m.pos);
+                        vision_levels.add(m.vision_level);
+                    });
                     group.gadgets.values().forEach(g -> {
                         int vision_level = Math.max(getGadgetVisionLevel(g.gadget_id), g.vision_level);
                         addGridPositionToMap(groupPositions.get(vision_level), group.id, vision_level, g.pos);
+                        vision_levels.add(vision_level);
                     });
                     group.npcs.values().forEach(n -> addGridPositionToMap(groupPositions.get(n.vision_level), group.id, n.vision_level, n.pos));
                     group.regions.values().forEach(r -> addGridPositionToMap(groupPositions.get(0), group.id, 0, r.pos));
                     if(group.garbages != null && group.garbages.gadgets != null) group.garbages.gadgets.forEach(g -> addGridPositionToMap(groupPositions.get(g.vision_level), group.id, g.vision_level, g.pos));
+
+                    int max_vision_level = -1;
+                    if(!vision_levels.isEmpty()) {
+                        for(int vision_level : vision_levels) {
+                            if(max_vision_level == -1 || visionOptions[max_vision_level].visionRange < visionOptions[vision_level].visionRange)
+                                max_vision_level = vision_level;
+                        }
+                    }
+                    if(max_vision_level == -1) max_vision_level = 0;
+
+                    addGridPositionToMap(groupPositions.get(max_vision_level), group.id, max_vision_level, group.pos);
                 });
             });
 

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -450,9 +450,9 @@ public class ScriptLib {
     private void printLog(String source, String msg){
         var currentGroup = this.currentGroup.getIfExists();
         if(currentGroup!=null) {
-            logger.info("[LUA] {} {} {}", source, currentGroup.id, msg);
+            logger.debug("[LUA] {} {} {}", source, currentGroup.id, msg);
         } else {
-            logger.info("[LUA] {} {}", source, msg);
+            logger.debug("[LUA] {} {}", source, msg);
         }
     }
 


### PR DESCRIPTION
## Description

- Mimic the original pos usage of group loading
- Revert PrintContextLog related to debug mode
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.