### PR TITLE
Fix variable refreshing and add GetGatherConfigIdList

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -227,11 +227,17 @@ public class SceneScriptManager {
 
         groupInstance.setTargetSuiteId(0);
 
-		if(prevSuiteData != null){
+		if(prevSuiteData != null) {
 			removeGroupSuite(group, prevSuiteData);
 		} //Remove old group suite
 
 		addGroupSuite(groupInstance, suiteData);
+
+        //Refesh variables here
+        group.variables.forEach(variable -> {
+            if(!variable.no_refresh)
+                groupInstance.getCachedVariables().put(variable.name, variable.value);
+        });
 
         groupInstance.setActiveSuiteId(suiteIndex);
         groupInstance.setLastTimeRefreshed(getScene().getWorld().getGameTime());
@@ -616,7 +622,7 @@ public class SceneScriptManager {
         // TODO delay
         var entity = scene.getEntityByConfigId(configId);
         if(entity!=null && entity.getGroupId() == group.id){
-            Grasscutter.getLogger().info("entity already exists failed in group {} with config {}", group.id, configId);
+            Grasscutter.getLogger().debug("entity already exists failed in group {} with config {}", group.id, configId);
             return;
         }
         entity = createMonster(group.id, group.block_id, group.monsters.get(configId));

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -1514,4 +1514,17 @@ public class ScriptLib {
 
         return gadget.getGroupId();
     }
+
+    public int[] GetGatherConfigIdList() {
+        EntityGadget gadget = getCurrentEntityGadget();
+
+        GameEntity[] children = (GameEntity[]) gadget.getChildren().toArray();
+
+        int[] configIds = new int[children.length + 1];
+        for(int i = 0; i < children.length; i++) {
+            configIds[i] = children[i].getConfigId();
+        }
+
+        return configIds;
+    }
 }

--- a/src/main/java/emu/grasscutter/scripts/data/controller/EntityController.java
+++ b/src/main/java/emu/grasscutter/scripts/data/controller/EntityController.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.scripts.data.controller;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.props.ElementType;
 import emu.grasscutter.scripts.ScriptLib;
@@ -32,6 +33,7 @@ public class EntityController {
     }
 
     public int onClientExecuteRequest(GameEntity entity, int param1, int param2, int param3) {
+        Grasscutter.getLogger().info("Request on {}, {}: {}", entity.getGroupId(), param1, entity.getPosition().toString());
         LuaValue value = callControllerScriptFunc(entity, "OnClientExecuteReq", LuaValue.valueOf(param1), LuaValue.valueOf(param2), LuaValue.valueOf(param3));
         if(value.isint() && value.toint() == 1) return 1;
 

--- a/src/main/java/emu/grasscutter/scripts/data/controller/EntityController.java
+++ b/src/main/java/emu/grasscutter/scripts/data/controller/EntityController.java
@@ -33,7 +33,7 @@ public class EntityController {
     }
 
     public int onClientExecuteRequest(GameEntity entity, int param1, int param2, int param3) {
-        Grasscutter.getLogger().info("Request on {}, {}: {}", entity.getGroupId(), param1, entity.getPosition().toString());
+        Grasscutter.getLogger().debug("Request on {}, {}: {}", entity.getGroupId(), param1, entity.getPosition().toString());
         LuaValue value = callControllerScriptFunc(entity, "OnClientExecuteReq", LuaValue.valueOf(param1), LuaValue.valueOf(param2), LuaValue.valueOf(param3));
         if(value.isint() && value.toint() == 1) return 1;
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerExecuteGadgetLuaReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerExecuteGadgetLuaReq.java
@@ -21,8 +21,6 @@ public class HandlerExecuteGadgetLuaReq extends PacketHandler {
         Player player = session.getPlayer();
         GameEntity entity = player.getScene().getEntities().get(req.getSourceEntityId());
 
-        Grasscutter.getLogger().info("Packet Request {}: {} {} {}", req.getSourceEntityId(), req.getParam1(), req.getParam2(), req.getParam3());
-
         int result = 1;
         if(entity instanceof EntityGadget gadget) result = gadget.onClientExecuteRequest(req.getParam1(), req.getParam2(), req.getParam3());
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerExecuteGadgetLuaReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerExecuteGadgetLuaReq.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.player.Player;
@@ -19,6 +20,8 @@ public class HandlerExecuteGadgetLuaReq extends PacketHandler {
 
         Player player = session.getPlayer();
         GameEntity entity = player.getScene().getEntities().get(req.getSourceEntityId());
+
+        Grasscutter.getLogger().info("Packet Request {}: {} {} {}", req.getSourceEntityId(), req.getParam1(), req.getParam2(), req.getParam3());
 
         int result = 1;
         if(entity instanceof EntityGadget gadget) result = gadget.onClientExecuteRequest(req.getParam1(), req.getParam2(), req.getParam3());


### PR DESCRIPTION
## Description

With this commit i solve a bug that doesn't take account what type of variables are refreshed to default value or not.
And this solves the gather points not showing the actual gather status on client. This is done at the same time of the update of the custom resources
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.