### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
@@ -9,6 +9,7 @@ import emu.grasscutter.game.quest.QuestValueCond;
 import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_STATE_EQUAL;
+import static emu.grasscutter.game.quest.enums.QuestState.QUEST_STATE_NONE;
 
 @QuestValueCond(QUEST_COND_STATE_EQUAL)
 public class ConditionStateEqual extends BaseCondition {
@@ -18,14 +19,8 @@ public class ConditionStateEqual extends BaseCondition {
         val questId = condition.getParam()[0];
         val questStateValue = condition.getParam()[1];
         val checkQuest = owner.getQuestManager().getQuestById(questId);
-        if (checkQuest == null) {
-            /*
-            Will spam the console
-            */
-            //QuestSystem.getLogger().debug("Warning: quest {} hasn't been started yet!", condition.getParam()[0]);
-            return false;
-        }
-        return checkQuest.getState().getValue() == questStateValue;
+        val curQuestState = checkQuest != null ? checkQuest.getState() : QUEST_STATE_NONE;
+        return curQuestState.getValue() == questStateValue;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
@@ -9,6 +9,7 @@ import emu.grasscutter.game.quest.QuestValueCond;
 import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_STATE_NOT_EQUAL;
+import static emu.grasscutter.game.quest.enums.QuestState.QUEST_STATE_NONE;
 
 @QuestValueCond(QUEST_COND_STATE_NOT_EQUAL)
 public class ConditionStateNotEqual extends BaseCondition {
@@ -17,16 +18,9 @@ public class ConditionStateNotEqual extends BaseCondition {
     public boolean execute(Player owner, SubQuestData questData, QuestAcceptCondition condition, String paramStr, int... params) {
         val questId = condition.getParam()[0];
         val questStateValue = condition.getParam()[1];
-        GameQuest checkQuest = owner.getQuestManager().getQuestById(questId);
-        if (checkQuest == null) {
-            /*
-            Will spam the console
-            */
-            //QuestSystem.getLogger().debug("Warning: quest {} hasn't been started yet!", condition.getParam()[0]);
-
-            return false;
-        }
-        return checkQuest.getState().getValue() != questStateValue;
+        val checkQuest = owner.getQuestManager().getQuestById(questId);
+        val curQuestState = checkQuest != null ? checkQuest.getState() : QUEST_STATE_NONE;
+        return curQuestState.getValue() != questStateValue;
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateEqual.java
@@ -7,6 +7,7 @@ import emu.grasscutter.game.quest.QuestValueContent;
 import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_QUEST_STATE_EQUAL;
+import static emu.grasscutter.game.quest.enums.QuestState.QUEST_STATE_NONE;
 
 @QuestValueContent(QUEST_CONTENT_QUEST_STATE_EQUAL)
 public class ContentQuestStateEqual extends BaseContent {
@@ -16,10 +17,8 @@ public class ContentQuestStateEqual extends BaseContent {
         val questId = condition.getParam()[0];
         val questState = condition.getParam()[1];
         val checkQuest = quest.getOwner().getQuestManager().getQuestById(questId);
-        if (checkQuest == null) {
-            return 0;
-        }
-        return checkQuest.getState().getValue() == questState ? 1 : 0;
+        val curQuestState = checkQuest != null ? checkQuest.getState() : QUEST_STATE_NONE;
+        return curQuestState.getValue() == questState ? 1 : 0;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateNotEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateNotEqual.java
@@ -7,6 +7,7 @@ import emu.grasscutter.game.quest.QuestValueContent;
 import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_QUEST_STATE_NOT_EQUAL;
+import static emu.grasscutter.game.quest.enums.QuestState.QUEST_STATE_NONE;
 
 @QuestValueContent(QUEST_CONTENT_QUEST_STATE_NOT_EQUAL)
 public class ContentQuestStateNotEqual extends BaseContent {
@@ -14,11 +15,9 @@ public class ContentQuestStateNotEqual extends BaseContent {
     public int initialCheck(GameQuest quest, SubQuestData questData, QuestContentCondition condition) {
         val questId = condition.getParam()[0];
         val questState = condition.getParam()[1];
-        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(questId);
-        if (checkQuest == null) {
-            return 0;
-        }
-        return checkQuest.getState().getValue() != questState ? 1 : 0;
+        val checkQuest = quest.getOwner().getQuestManager().getQuestById(questId);
+        val curQuestState = checkQuest != null ? checkQuest.getState() : QUEST_STATE_NONE;
+        return curQuestState.getValue() != questState ? 1 : 0;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
+++ b/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
@@ -104,10 +104,16 @@ public class WorldDataSystem extends BaseGameSystem {
             return null;
         }
 
-        var monster = group.getMonsters().values().stream()
+        val monsterOpt = group.getMonsters().values().stream()
                 .filter(x -> x.getMonster_id() == monsterId)
                 .findFirst();
-        if (monster.isEmpty()) {
+        if (monsterOpt.isEmpty()) {
+            return null;
+        }
+        val monster = monsterOpt.get();
+        val monsterPos = monster.getPos();
+        if(monsterPos == null){
+            Grasscutter.getLogger().error("null monster pos in investigationGroup {} in scene{}:", groupId, sceneId);
             return null;
         }
 
@@ -118,11 +124,11 @@ public class WorldDataSystem extends BaseGameSystem {
                 .setSceneId(imd.getCityData().getSceneId())
                 .setGroupId(groupId)
                 .setMonsterId(monsterId)
-                .setLevel(getMonsterLevel(monster.get(), player.getWorld()))
+                .setLevel(getMonsterLevel(monster, player.getWorld()))
                 .setIsAlive(true)
                 .setNextRefreshTime(Integer.MAX_VALUE)
                 .setRefreshInterval(Integer.MAX_VALUE)
-                .setPos(monster.get().getPos().toProto());
+                .setPos(monsterPos.toProto());
 
         if ("Boss".equals(imd.getMonsterCategory())) {
             var bossChest = group.searchBossChestInGroup();

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientScriptEventNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientScriptEventNotify.java
@@ -5,6 +5,7 @@ import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.ClientScriptEventNotifyOuterClass.ClientScriptEventNotify;
+import emu.grasscutter.scripts.constants.EventType;
 import emu.grasscutter.scripts.data.ScriptArgs;
 import emu.grasscutter.server.game.GameSession;
 import lombok.val;
@@ -26,6 +27,12 @@ public class HandlerClientScriptEventNotify extends PacketHandler {
                 case 0 -> args.setParam1(data.getParamList(i));
                 case 1 -> args.setParam2(data.getParamList(i));
                 case 2 -> args.setParam3(data.getParamList(i));
+            }
+        }
+        if(data.getEventType() == EventType.EVENT_AVATAR_NEAR_PLATFORM){
+            val entity = scriptManager.getScene().getEntityById(data.getSourceEntityId());
+            if(entity != null){
+                args.setParam1(entity.getConfigId());
             }
         }
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGetSceneAreaRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGetSceneAreaRsp.java
@@ -1,10 +1,12 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.CityInfoOuterClass.CityInfo;
 import emu.grasscutter.net.proto.GetSceneAreaRspOuterClass.GetSceneAreaRsp;
+import lombok.val;
 
 public class PacketGetSceneAreaRsp extends BasePacket {
 
@@ -13,13 +15,16 @@ public class PacketGetSceneAreaRsp extends BasePacket {
 
         this.buildHeader(0);
 
-        GetSceneAreaRsp p = GetSceneAreaRsp.newBuilder()
+        val p = GetSceneAreaRsp.newBuilder()
                 .setSceneId(sceneId)
-                .addAllAreaIdList(player.getUnlockedSceneAreas(sceneId))
-                .addCityInfoList(CityInfo.newBuilder().setCityId(1).setLevel(1).build())
-                .addCityInfoList(CityInfo.newBuilder().setCityId(2).setLevel(1).build())
-                .addCityInfoList(CityInfo.newBuilder().setCityId(3).setLevel(1).build())
-                .build();
+                .addAllAreaIdList(player.getUnlockedSceneAreas(sceneId));
+
+        GameData.getCityDataMap().values().stream().filter(cityData -> cityData.getSceneId() == sceneId).forEach(cityData -> {
+            p.addCityInfoList(CityInfo.newBuilder()
+                .setCityId(cityData.getCityId())
+                .setLevel(1)
+                .build());
+        });
 
         this.setData(p);
     }


### PR DESCRIPTION
* Fixed quest content/cond checks checking for unstarted quests (thx @scooterboo )
* Add the actual cfg id to client send EVENT_AVATAR_NEAR_PLATFORM events (thx @scooterboo )
* Actually send the unlocked areas from the player instead of a brute forced list
* Use city data to generate the city list in GetSceneAreaRsp, instead of a hard coded list
* Catch null positions in WorldDataSystems getInvestigationMonster