### PR TITLE
Fix typo in ChapterData.java

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/ChapterData.java
+++ b/src/main/java/emu/grasscutter/data/excels/ChapterData.java
@@ -28,6 +28,6 @@ public class ChapterData extends GameResource {
     @Override
     public void onLoad() {
         beginQuestChapterMap.put(beginQuestId, this);
-        beginQuestChapterMap.put(endQuestId, this);
+        endQuestChapterMap.put(endQuestId, this);
     }
 }


### PR DESCRIPTION
## Description
At the start of the last quest in an act, a banner would appear saying that you *started* the act:

![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/c1c0135e-8173-46e5-aaef-92e19ed4a2de)

There was a typo in ChapterData.java where endQuestChapterMap was incorrectly beginQuestChapterMap.
This is fix already in main grasscutter, but the history is gone.

With the corrections:
![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/3f573c57-3895-480c-a7c5-f8fcce57d832)
Works great!


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.