### PR TITLE
Fix bug with region leave not resetting properly

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
@@ -68,7 +68,10 @@ public class EntityRegion extends GameEntity{
         this.entityLeave = true;
     }
     public boolean entityLeave() {return this.entityLeave;}
-    public void resetEntityLeave() {this.entityLeave = false;}
+    public void resetEntityLeave() {
+        this.entityLeave = false;
+        leftEntities.clear();
+    }
     @Override public Int2FloatMap getFightProperties() {return null;}
 
     @Override public Position getPosition() {return position;}


### PR DESCRIPTION
## Description
While debugging a different problem, I noticed that the Avatar was leaving every region every refresh tick.

Before:

https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/3a2656fe-8eda-4782-acca-ca8a0be38599


I found that leftEntities was not being cleared like newEntities. I looked at resetNewEntities and added the symmetric code to resetEntityLeave.

After:

https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/19ac71ca-156d-4286-86c4-e03fe0f66e61

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.