### PR TITLE
Handle concurrent saving error

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -314,7 +314,11 @@ public final class DatabaseHelper {
     }
 
     public static void saveQuest(GameMainQuest quest) {
-        DatabaseManager.getGameDatastore().save(quest);
+        try {
+            DatabaseManager.getGameDatastore().save(quest);
+        } catch(Exception exception){
+            Grasscutter.getLogger().error("Failed to save quest m{}",quest.getParentQuestId(), exception);
+        }
     }
 
     public static boolean deleteQuest(GameMainQuest quest) {


### PR DESCRIPTION
## Description
At the end of An Impromptu Change of Plan, only one of the three Adepti quests fired: Wangshu
When Wangshu saves, the timing on my computer makes it save two times at the same time (for 100301 and 100320).
When this happens, a `E11000 duplicate key error collection: grasscutter.quests index: _id_ dup key: { _id: ObjectId('65ceb86e3a88695a7c17d491') }` is thrown, and the quest accept system bails. The quest system ends up not accepting the other two Adepti quests.

A long term fix would be for the main quest to not save to the backup database as things change, but to save in batches. For example on world ticks or every 30s worth of world ticks.

This proposed fix makes it gracefully fail and continue to accept quests if saving fails.

![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/dac6b40a-3920-4507-a749-eb05f87e84f9)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Mitigation
- [ ] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.