### PR TITLE
Rewind Changes

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -346,7 +346,7 @@ public class GameMainQuest {
         return true;
     }
 
-    public void checkProgress(){
+    public void restartProgress(){
         if (this.questManager == null) {
             this.questManager = getOwner().getQuestManager();
         }

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -90,7 +90,7 @@ public class GameMainQuest {
         }
     }
 
-    public Collection<GameQuest> getActiveQuests(){
+    public Collection<GameQuest> getUnfinishedQuests(){
         return childQuests.values().stream()
             .filter(q->q.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue())
             .toList();
@@ -258,7 +258,8 @@ public class GameMainQuest {
         if (this.questManager == null) {
             this.questManager = getOwner().getQuestManager();
         }
-        var activeQuests = getActiveQuests();
+        var activeQuests = getChildQuests().values().stream()
+                .filter(p -> (p.getState() == QuestState.QUEST_STATE_UNFINISHED || p.getState() == QuestState.QUEST_STATE_FINISHED)).toList();
         var highestActiveQuest = activeQuests.stream()
             .filter(q -> q.getQuestData() != null)
             .max(Comparator.comparing(q -> q.getQuestData().getOrder()))

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -253,7 +253,7 @@ public class GameMainQuest {
         return null;
     }
 
-    public GameQuest findRewindTarget(){
+    public GameQuest getRewindTarget(){
         var activeQuests = getChildQuests().values().stream()
             .filter(p -> (p.getState() == QuestState.QUEST_STATE_UNFINISHED || p.getState() == QuestState.QUEST_STATE_FINISHED)).toList();
         var highestActiveQuest = activeQuests.stream()
@@ -285,23 +285,13 @@ public class GameMainQuest {
     }
 
     // Rewinds to the last finished/unfinished rewind quest, and returns the avatar rewind position (if it exists)
-    public List<Position> rewind(boolean onLogin) {
+    public List<Position> rewind() {
         if (this.questManager == null) {
             this.questManager = getOwner().getQuestManager();
         }
-        val rewindTarget = findRewindTarget();
+        val rewindTarget = getRewindTarget();
         if(rewindTarget == null) return null;
-        val position = rewindTo(rewindTarget, false);
-
-        if(onLogin) {
-            //execute all the beginExec before the rewind target on UNFINISHED quests on login only
-            this.getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() < rewindTarget.getQuestData().getOrder()
-                    && p.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue()).forEach(q -> {
-                q.getQuestData().getBeginExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(q, e, e.getParam()));
-            });
-        }
-
-        return position;
+        return rewindTo(rewindTarget, false);
     }
 
     public boolean hasRewindPosition(int subId, List<Position> posAndRot){

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -90,7 +90,7 @@ public class GameMainQuest {
         }
     }
 
-    public Collection<GameQuest> getUnfinishedQuests(){
+    public Collection<GameQuest> getActiveQuests(){
         return childQuests.values().stream()
             .filter(q->q.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue())
             .toList();
@@ -258,8 +258,7 @@ public class GameMainQuest {
         if (this.questManager == null) {
             this.questManager = getOwner().getQuestManager();
         }
-        var activeQuests = getChildQuests().values().stream()
-                .filter(p -> (p.getState() == QuestState.QUEST_STATE_UNFINISHED || p.getState() == QuestState.QUEST_STATE_FINISHED)).toList();
+        var activeQuests = getActiveQuests();
         var highestActiveQuest = activeQuests.stream()
             .filter(q -> q.getQuestData() != null)
             .max(Comparator.comparing(q -> q.getQuestData().getOrder()))
@@ -348,8 +347,13 @@ public class GameMainQuest {
     }
 
     public void checkProgress(){
+        if (this.questManager == null) {
+            this.questManager = getOwner().getQuestManager();
+        }
         for (var quest : getChildQuests().values()){
             if(quest.getState() == QuestState.QUEST_STATE_UNFINISHED) {
+                quest.clearProgress(false);
+                quest.start();
                 questManager.checkQuestAlreadyFullfilled(quest);
             }
         }

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -245,24 +245,11 @@ public class GameQuest {
 
     // Return true if it did the rewind
     public boolean rewind(boolean notifyDelete) {
-        //rewind everything after the rewind target
         getMainQuest().getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() > this.getQuestData().getOrder()).forEach(q -> {
             q.clearProgress(notifyDelete);
         });
-
-        //rewind and restart everything UNFINISHED before the rewind target
-        getMainQuest().getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() < this.getQuestData().getOrder()
-                && p.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue()).forEach(q -> {
-            q.clearProgress(notifyDelete);
-            q.start();
-        });
-
-        //rewind and restart itself if it is UNFINISHED
-        if(this.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue()) {
-            clearProgress(notifyDelete);
-            this.start();
-        }
-
+        clearProgress(notifyDelete);
+        this.start();
         return true;
     }
 

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -245,11 +245,24 @@ public class GameQuest {
 
     // Return true if it did the rewind
     public boolean rewind(boolean notifyDelete) {
+        //rewind everything after the rewind target
         getMainQuest().getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() > this.getQuestData().getOrder()).forEach(q -> {
             q.clearProgress(notifyDelete);
         });
-        clearProgress(notifyDelete);
-        this.start();
+
+        //rewind and restart everything UNFINISHED before the rewind target
+        getMainQuest().getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() < this.getQuestData().getOrder()
+                && p.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue()).forEach(q -> {
+            q.clearProgress(notifyDelete);
+            q.start();
+        });
+
+        //rewind and restart itself if it is UNFINISHED
+        if(this.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue()) {
+            clearProgress(notifyDelete);
+            this.start();
+        }
+
         return true;
     }
 

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -245,11 +245,15 @@ public class GameQuest {
 
     // Return true if it did the rewind
     public boolean rewind(boolean notifyDelete) {
+        //rewind everything after the rewind target
         getMainQuest().getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() > this.getQuestData().getOrder()).forEach(q -> {
             q.clearProgress(notifyDelete);
         });
+
+        //rewind and restart itself
         clearProgress(notifyDelete);
         this.start();
+
         return true;
     }
 

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -106,7 +106,7 @@ public class QuestManager extends BasePlayerManager {
     public void onLogin() {
         List<GameMainQuest> activeQuests = getActiveMainQuests();
         for (GameMainQuest quest : activeQuests) {
-            quest.checkProgress();
+            quest.restartProgress();
         }
         player.getActivityManager().triggerActivityConditions();
     }

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -104,15 +104,8 @@ public class QuestManager extends BasePlayerManager {
     }
 
     public void onLogin() {
-
         List<GameMainQuest> activeQuests = getActiveMainQuests();
-        List<GameQuest> activeSubs = new ArrayList<>(activeQuests.size());
         for (GameMainQuest quest : activeQuests) {
-            List<Position> rewindPos = quest.rewind(); // <pos, rotation>
-            if (rewindPos != null) {
-                getPlayer().getPosition().set(rewindPos.get(0));
-                getPlayer().getRotation().set(rewindPos.get(1));
-            }
             quest.checkProgress();
         }
         player.getActivityManager().triggerActivityConditions();

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -106,7 +106,12 @@ public class QuestManager extends BasePlayerManager {
     public void onLogin() {
         List<GameMainQuest> activeQuests = getActiveMainQuests();
         for (GameMainQuest quest : activeQuests) {
-            quest.restartProgress();
+            List<Position> rewindPos = quest.rewind(true); // <pos, rotation>
+            if (rewindPos != null) {
+                getPlayer().getPosition().set(rewindPos.get(0));
+                getPlayer().getRotation().set(rewindPos.get(1));
+            }
+            quest.checkProgress();
         }
         player.getActivityManager().triggerActivityConditions();
     }

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -109,14 +109,9 @@ public class QuestManager extends BasePlayerManager {
         List<GameQuest> activeSubs = new ArrayList<>(activeQuests.size());
         for (GameMainQuest quest : activeQuests) {
             List<Position> rewindPos = quest.rewind(); // <pos, rotation>
-            var activeQuest = quest.getActiveQuests();
             if (rewindPos != null) {
                 getPlayer().getPosition().set(rewindPos.get(0));
                 getPlayer().getRotation().set(rewindPos.get(1));
-            }
-            if(activeQuest!=null && rewindPos!=null){
-                //activeSubs.add(activeQuest);
-                //player.sendPacket(new PacketQuestProgressUpdateNotify(activeQuest));
             }
             quest.checkProgress();
         }

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecRollbackParentQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecRollbackParentQuest.java
@@ -11,7 +11,7 @@ import emu.grasscutter.server.packet.send.PacketScenePlayerLocationNotify;
 public class ExecRollbackParentQuest extends QuestExecHandler {
     @Override
     public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
-        var targetPosition = quest.getMainQuest().rewind();
+        var targetPosition = quest.getMainQuest().rewind(false);
         if(targetPosition == null){
             return false;
         }

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecRollbackParentQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecRollbackParentQuest.java
@@ -11,7 +11,7 @@ import emu.grasscutter.server.packet.send.PacketScenePlayerLocationNotify;
 public class ExecRollbackParentQuest extends QuestExecHandler {
     @Override
     public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
-        var targetPosition = quest.getMainQuest().rewind(false);
+        var targetPosition = quest.getMainQuest().rewind();
         if(targetPosition == null){
             return false;
         }


### PR DESCRIPTION
## Description
This is a WIP for changes to the rewind system.
Fixes problems I had rewinding this quest in https://github.com/Anime-Game-Servers/Grasscutter-Quests/issues/104 in 1009xx:
![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/25e6042b-14b5-4357-b46f-6218ac6f074a)

and this one in 1021xx:
![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/7a0f2117-4890-43ef-8659-4295a41956d5)

The original code very much looked like it thought it would be green up to one orange quest, and then red thereafter.

This new code will roll back to the first green/orange quest that's a valid rollback quest. Previously it would roll back to the first orange quest.

This new code will execute all BeginExec on a login.

## Issues fixed by this PR
https://github.com/Anime-Game-Servers/Grasscutter-Quests/issues/104

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.