### PR TITLE
Downstream PacketQuestGlobalVarNotify

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -195,19 +195,29 @@ public class QuestManager extends BasePlayerManager {
     public void setQuestGlobalVarValue(Integer variable, Integer value) {
         Integer previousValue = getPlayer().getQuestGlobalVariables().put(variable,value);
         QuestSystem.getLogger().debug("Changed questGlobalVar {} value from {} to {}", variable, previousValue==null ? 0: previousValue, value);
+        this.triggerQuestGlobalVarAction(variable, value);
     }
+
     public void incQuestGlobalVarValue(Integer variable, Integer inc) {
-        //
         Integer previousValue = getPlayer().getQuestGlobalVariables().getOrDefault(variable,0);
         getPlayer().getQuestGlobalVariables().put(variable,previousValue + inc);
         QuestSystem.getLogger().debug("Incremented questGlobalVar {} value from {} to {}", variable, previousValue, previousValue + inc);
+        this.triggerQuestGlobalVarAction(variable, inc);
     }
+
     //In MainQuest 998, dec is passed as a positive integer
     public void decQuestGlobalVarValue(Integer variable, Integer dec) {
-        //
         Integer previousValue = getPlayer().getQuestGlobalVariables().getOrDefault(variable,0);
         getPlayer().getQuestGlobalVariables().put(variable,previousValue - dec);
         QuestSystem.getLogger().debug("Decremented questGlobalVar {} value from {} to {}", variable, previousValue, previousValue - dec);
+        this.triggerQuestGlobalVarAction(variable, dec);
+    }
+
+    public void triggerQuestGlobalVarAction(int variable, int value) {
+        this.queueEvent(QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_EQUAL, variable, value);
+        this.queueEvent(QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_GREATER, variable, value);
+        this.queueEvent(QuestCond.QUEST_COND_QUEST_GLOBAL_VAR_LESS, variable, value);
+        this.getPlayer().sendPacket(new PacketQuestGlobalVarNotify(getPlayer()));
     }
 
     public GameMainQuest getMainQuestById(int mainQuestId) {

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestGlobalVarNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestGlobalVarNotify.java
@@ -1,0 +1,26 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.QuestGlobalVarNotifyOuterClass.QuestGlobalVarNotify;
+import emu.grasscutter.net.proto.QuestGlobalVarOuterClass.QuestGlobalVar;
+
+public final class PacketQuestGlobalVarNotify extends BasePacket {
+    public PacketQuestGlobalVarNotify(Player player) {
+        super(PacketOpcodes.QuestGlobalVarNotify);
+
+        this.setData(
+                QuestGlobalVarNotify.newBuilder()
+                        .addAllVarList(
+                                player.getQuestGlobalVariables().entrySet().stream()
+                                        .map(
+                                                entry ->
+                                                        QuestGlobalVar.newBuilder()
+                                                                .setKey(entry.getKey())
+                                                                .setValue(entry.getValue())
+                                                                .build())
+                                        .toList())
+                        .build());
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestGlobalVarNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestGlobalVarNotify.java
@@ -1,26 +1,13 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestGlobalVarNotifyOuterClass.QuestGlobalVarNotify;
-import emu.grasscutter.net.proto.QuestGlobalVarOuterClass.QuestGlobalVar;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import messages.quest.QuestGlobalVarNotify;
+import messages.quest.QuestGlobalVar;
 
-public final class PacketQuestGlobalVarNotify extends BasePacket {
+public class PacketQuestGlobalVarNotify extends BaseTypedPacket<QuestGlobalVarNotify> {
     public PacketQuestGlobalVarNotify(Player player) {
-        super(PacketOpcodes.QuestGlobalVarNotify);
-
-        this.setData(
-                QuestGlobalVarNotify.newBuilder()
-                        .addAllVarList(
-                                player.getQuestGlobalVariables().entrySet().stream()
-                                        .map(
-                                                entry ->
-                                                        QuestGlobalVar.newBuilder()
-                                                                .setKey(entry.getKey())
-                                                                .setValue(entry.getValue())
-                                                                .build())
-                                        .toList())
-                        .build());
+        super(new QuestGlobalVarNotify(player.getQuestGlobalVariables().entrySet().stream()
+            .map(entry -> new QuestGlobalVar(entry.getKey(),entry.getValue())).toList()));
     }
 }


### PR DESCRIPTION
## Description
Can you believe it? We're living in the future now. A future where quests can QUEST_EXEC_SET_QUEST_GLOBAL_VAR in harmony.

102305 (Heart of Glaze) uses a QUEST_EXEC_SET_QUEST_GLOBAL_VAR to set 10009 to 1. This starts quest 102401 (Turning Point).
Without PacketQuestGlobalVarNotify, the client isn't notified that the global variable changed. You are left standing in Golden House at the end of the Childe battle.

Code was downstreamed from Grasscutter. That's why it looks so ＲＥＡＤＡＢＬＥ.


## Issues fixed by this PR
m1024: Turning Point can start and also fail/rollback correctly.


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.