### PR TITLE
link AddBlossomScheduleProgressByGroupId to addBlossomProgress

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/ScriptLibHandler.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLibHandler.java
@@ -1051,7 +1051,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
 
     @Override
     public int AddBlossomScheduleProgressByGroupId(GroupEventLuaContext context, int groupId) {
-        return handleUnimplemented(groupId);
+        logger.debug("[LUA] Call check AddBlossomScheduleProgressByGroupId with {}", groupId);
+        val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
+        return blossomManager.addBlossomProgress(groupId) ? 0 : 1;
     }
 
     @Override


### PR DESCRIPTION
## Description
When interacting with Ley Line Outcrops, a `Defeat all opponents  0/7` notif appears, but defeating all of the enemies does nothing.

![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/e9f0eab8-9df6-43a6-90ca-cb3d65d1421e)

I quickly found that unimplemented ScriptLibHander.AddBlossomScheduleProgressByGroupId was being called every time a monster was defeated and that BlossomManager had a unused function addBlossomProgress with the note: `Update Blossom camp's progress (on monster die for example), triggered by ScriptLib`. I noticed by looking at the lua that if only a EVENT_BLOSSOM_PROGRESS_FINISH was called, the group's sequence could continue. addBlossomProgress has a EVENT_BLOSSOM_PROGRESS_FINISH in it. I'm pretty sure linking these up is the right thing to do.

After linking them up, progress happened correctly!

![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/8d6d1d41-b8d9-4dc2-aedf-94eea9c4292f)



## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.