### PR TITLE
In EVENT_GADGET_STATE_CHANGE, param3 is the previous state

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -134,12 +134,12 @@ public class EntityGadget extends EntityBaseGadget implements ConfigAbilityDataA
 
     public void updateState(int state) {
         if(state == this.getState()) return; //Don't triggers events
-
+        val oldState = this.getState();
         this.setState(state);
         ticksSinceChange = getScene().getSceneTimeSeconds();
         this.getScene().broadcastPacket(new PacketGadgetStateNotify(this, state));
         getScene().getScriptManager().callEvent(new ScriptArgs(this.getGroupId(), EventType.EVENT_GADGET_STATE_CHANGE)
-            .setParam1(state).setParam2(this.getConfigId()).setSourceEntityId(getId()));
+            .setParam1(state).setParam2(this.getConfigId()).setParam3(oldState).setSourceEntityId(getId()));
     }
 
     @Deprecated(forRemoval = true) // Dont use!


### PR DESCRIPTION
## Description
In EVENT_GADGET_STATE_CHANGE, param3 is the previous state.

## Issues fixed by this PR
Conditions can be fulfilled, and the group lua can continue into the action section.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.