### PR TITLE
Have timers trigger by events with source = ""

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -993,19 +993,12 @@ public class SceneScriptManager {
         }
         logger.info("creating group timer event for group {} with source {} and time {}",
             groupID, source, time);
-        for(SceneTrigger trigger : group.getTriggers().values()){
-            if(trigger.getEvent() == EVENT_TIMER_EVENT &&trigger.getSource().equals(source)){
-                logger.warn("[LUA] Found timer trigger with source {} for group {} : {}",
-                    source, groupID, trigger.getName());
-                cancelGroupTimerEvent(groupID, source);
-                var taskIdentifier = Grasscutter.getGameServer().getScheduler().scheduleDelayedRepeatingTask(() ->
-                    callEvent(new ScriptArgs(groupID, EVENT_TIMER_EVENT)
-                        .setEventSource(source)), (int)time, (int)time);
-                var groupTasks = activeGroupTimers.computeIfAbsent(groupID, k -> new HashSet<>());
-                groupTasks.add(new Pair<>(source, taskIdentifier));
-
-            }
-        }
+        cancelGroupTimerEvent(groupID, source);
+        var taskIdentifier = Grasscutter.getGameServer().getScheduler().scheduleDelayedRepeatingTask(() ->
+            callEvent(new ScriptArgs(groupID, EVENT_TIMER_EVENT)
+                .setEventSource(source)), (int)time, (int)time);
+        var groupTasks = activeGroupTimers.computeIfAbsent(groupID, k -> new HashSet<>());
+        groupTasks.add(new Pair<>(source, taskIdentifier));
         return 0;
     }
     public int cancelGroupTimerEvent(int groupID, String source) {


### PR DESCRIPTION
## Description
Was trying to trigger Boreas, but ran into problems with his pre-battle timer not being created. (group 133002259).

There's some more traditional pyro monuments close by with the same issue (group 133002344)

The old code has several flaws:
* If the EVENT_TIMER_EVENT has source = "", the timer never gets created.
* If multiple EVENT_TIMER_EVENT match the source (like if you made the code check if trigger.getSource().equals("")), the timer is canceled and created over and over on each iteration that matches. Only the last timer remains.
* All of it doesn't matter anyway since the callEvent in realCallEvent (line 725 or so) is going to handle the EVENT_TIMER_EVENT for every timer trigger where the source matches the source or the source is "".

Iteration and source checking does not make sense here. You don't need to manually check the source (the source is checked later), you don't need to make the timer multiple times (it's run multiple times later).

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.