### PR TITLE
Update ActionLoseHP.java to ignore Infinite CUR_HP

### DIFF
--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionLoseHP.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionLoseHP.java
@@ -42,7 +42,10 @@ public class ActionLoseHP extends AbilityActionHandler {
         float amountToLose = amount;
         amountToLose += amountByCasterMaxHPRatio * owner.getFightProperty(FightProperty.FIGHT_PROP_MAX_HP);
         amountToLose += amountByCasterAttackRatio * owner.getFightProperty(FightProperty.FIGHT_PROP_CUR_ATTACK);
-        amountToLose += amountByCasterCurrentHPRatio * owner.getFightProperty(FightProperty.FIGHT_PROP_CUR_HP);
+        //Ignore amountByCasterCurrentHPRatio if owner has Infinite HP
+        if(owner.getFightProperty(FightProperty.FIGHT_PROP_CUR_HP) != Float.POSITIVE_INFINITY) {
+            amountToLose += amountByCasterCurrentHPRatio * owner.getFightProperty(FightProperty.FIGHT_PROP_CUR_HP);
+        }
 
         float currentHp = target.getFightProperty(FightProperty.FIGHT_PROP_CUR_HP);
         float maxHp = target.getFightProperty(FightProperty.FIGHT_PROP_MAX_HP);


### PR DESCRIPTION
## Description
In dungeon 1114 (scene 20104), when the floor in front of the statue is activated (/entity 3014 state201), the player's health becomes NaN: 

![image](https://github.com/Anime-Game-Servers/Grasscutter-Quests/assets/1877986/b4f9ecaf-1e47-4f51-94e5-97283d429e51)

This is because part of the damage equation uses the floor's current HP, which is Infinite. We set the current HP of invincible objects to Positive infinity when they are created.


amountByCasterCurrentHPRatio is zero, FIGHT_PROP_CUR_HP is Infinity.
Multiplying zero by Infinity results in NaN. Adding anything to NaN is NaN

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.