### PR TITLE
Replace PacketOpcodes references with strings

### DIFF
--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -245,8 +245,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
             player.onLogout();
         }
         try {
-            val disconnectPacketId = getPackageIdProvider().getPacketId("ServerDisconnectClientNotify");
-            send(new BasePacket(disconnectPacketId));
+            send(new BasePacket(getPackageIdProvider().getPacketId("ServerDisconnectClientNotify")));
         } catch (Throwable ignore) {
             Grasscutter.getLogger().warn("closing {} error", getAddress().getAddress().getHostAddress());
         }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerForceExitReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerForceExitReq.java
@@ -11,7 +11,7 @@ public class HandlerPlayerForceExitReq extends PacketHandler {
 	@Override
 	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
 		// Client should auto disconnect right now
-		session.send(new BasePacket(PacketOpcodes.PlayerForceExitRsp));
+        session.send(new BasePacket(session.getPackageIdProvider().getPacketId("PlayerForceExitRsp")));
 		new Thread(){
 			@Override
 			public void run() {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerLoginReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerLoginReq.java
@@ -31,7 +31,7 @@ public class HandlerPlayerLoginReq extends TypedPacketHandler<PlayerLoginReq> {
         if (player.getAvatars().getAvatarCount() == 0) {
             // Pick character
             session.setState(SessionState.PICKING_CHARACTER);
-            session.send(new BasePacket(PacketOpcodes.DoSetPlayerBornDataNotify));
+            session.send(new BasePacket(session.getPackageIdProvider().getPacketId("DoSetPlayerBornDataNotify")));
         } else {
             // Login done
             session.getPlayer().onLogin();

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerQuitDungeonReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerQuitDungeonReq.java
@@ -14,6 +14,6 @@ public class HandlerPlayerQuitDungeonReq extends PacketHandler {
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         val req = PlayerQuitDungeonReq.parseFrom(payload);
         session.getPlayer().getServer().getDungeonSystem().exitDungeon(session.getPlayer(), req.getIsQuitImmediately());
-        session.getPlayer().sendPacket(new BasePacket(PacketOpcodes.PlayerQuitDungeonRsp));
+        session.getPlayer().sendPacket(new BasePacket(session.getPackageIdProvider().getPacketId("PlayerQuitDungeonRsp")));
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuickUseWidgetReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuickUseWidgetReq.java
@@ -43,7 +43,7 @@ public class HandlerQuickUseWidgetReq extends PacketHandler {
                 }
                 proto.setMaterialId(materialId);
                 inventory.removeItem(item,1);// decrease count
-                BasePacket rsp = new BasePacket(PacketOpcodes.QuickUseWidgetRsp);
+                BasePacket rsp = new BasePacket(session.getPackageIdProvider().getPacketId("QuickUseWidgetRsp"));
                 rsp.setData(proto);
                 session.send(rsp);
                 Grasscutter.getLogger().warn("class has no effects in the game, feel free to implement it");

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSceneInitFinishReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSceneInitFinishReq.java
@@ -24,7 +24,7 @@ public class HandlerSceneInitFinishReq extends TypedPacketHandler<SceneInitFinis
 		session.send(new PacketWorldDataNotify(session.getPlayer().getWorld()));
         session.send(new PacketWorldOwnerBlossomBriefInfoNotify(session.getPlayer().getWorld()));
 		session.send(new PacketPlayerWorldSceneInfoListNotify(session.getPlayer()));
-		session.send(new BasePacket(PacketOpcodes.SceneForceUnlockNotify));
+        session.send(new BasePacket(session.getPackageIdProvider().getPacketId("SceneForceUnlockNotify")));
 		session.send(new PacketHostPlayerNotify(session.getPlayer().getWorld()));
 		session.send(new PacketSceneDataNotify(session.getPlayer()));
 		session.send(new PacketSceneTimeNotify(session.getPlayer()));

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetEntityClientDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetEntityClientDataNotify.java
@@ -9,20 +9,20 @@ import emu.grasscutter.server.game.GameSession;
 
 @Opcodes(PacketOpcodes.SetEntityClientDataNotify)
 public class HandlerSetEntityClientDataNotify extends PacketHandler {
-	
+
 	@Override
 	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
 		// Skip if there is no one to broadcast it too
 		if (session.getPlayer().getScene().getPlayerCount() <= 1) {
 			return;
 		}
-		
+
 		// Make sure packet is a valid proto before replaying it to the other players
 		SetEntityClientDataNotify notif = SetEntityClientDataNotify.parseFrom(payload);
-		
-		BasePacket packet = new BasePacket(PacketOpcodes.SetEntityClientDataNotify, true);
+
+        BasePacket packet = new BasePacket(session.getPackageIdProvider().getPacketId("SetEntityClientDataNotify"), true);
 		packet.setData(notif);
-		
+
 		session.getPlayer().getScene().broadcastPacket(packet);
 	}
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
@@ -64,7 +64,7 @@ public class HandlerSetPlayerBornDataReq extends PacketHandler {
         session.getPlayer().onPlayerBorn();
 
         // Born resp packet
-        session.send(new BasePacket(PacketOpcodes.SetPlayerBornDataRsp));
+        session.send(new BasePacket(session.getPackageIdProvider().getPacketId("SetPlayerBornDataRsp")));
 
         // Default mail
         var welcomeMail = GAME_INFO.joinOptions.welcomeMail;


### PR DESCRIPTION
Replace
session.send(new BasePacket(PacketOpcodes.Packet)); 
with
session.send(new BasePacket(session.getPackageIdProvider().getPacketId("Packet")));

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.