### PR TITLE
Moved a lot of protos over to multiprotos

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -15,7 +15,6 @@ import emu.grasscutter.game.props.EntityIdType;
 import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.game.world.SceneGroupInstance;
-import emu.grasscutter.net.proto.VisionTypeOuterClass;
 import emu.grasscutter.scripts.EntityControllerScriptManager;
 import emu.grasscutter.server.packet.send.PacketGadgetStateNotify;
 import emu.grasscutter.server.packet.send.PacketPlatformStartRouteNotify;
@@ -29,12 +28,13 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.val;
-import org.anime_game_servers.multi_proto.gi.messages.gadget.GadgetInteractReq;
-import org.anime_game_servers.multi_proto.gi.messages.general.ability.AbilitySyncStateInfo;
-import org.anime_game_servers.multi_proto.gi.messages.scene.entity.*;
 import org.anime_game_servers.gi_lua.models.ScriptArgs;
 import org.anime_game_servers.gi_lua.models.constants.EventType;
 import org.anime_game_servers.gi_lua.models.scene.group.SceneGadget;
+import org.anime_game_servers.multi_proto.gi.messages.gadget.GadgetInteractReq;
+import org.anime_game_servers.multi_proto.gi.messages.general.ability.AbilitySyncStateInfo;
+import org.anime_game_servers.multi_proto.gi.messages.scene.VisionType;
+import org.anime_game_servers.multi_proto.gi.messages.scene.entity.*;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -201,7 +201,7 @@ public class EntityGadget extends EntityBaseGadget implements ConfigAbilityDataA
     public void onRemoved() {
         super.onRemoved();
         if(!children.isEmpty()) {
-            getScene().removeEntities(children, VisionTypeOuterClass.VisionType.VISION_TYPE_REMOVE);
+            getScene().removeEntities(children, VisionType.VISION_REMOVE);
             children.clear();
         }
     }

--- a/src/main/java/emu/grasscutter/game/friends/FriendsList.java
+++ b/src/main/java/emu/grasscutter/game/friends/FriendsList.java
@@ -1,18 +1,14 @@
 package emu.grasscutter.game.friends;
 
-import java.util.List;
-
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.player.BasePlayerManager;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.proto.DealAddFriendResultTypeOuterClass.DealAddFriendResultType;
-import emu.grasscutter.server.packet.send.PacketAskAddFriendNotify;
-import emu.grasscutter.server.packet.send.PacketAskAddFriendRsp;
-import emu.grasscutter.server.packet.send.PacketDealAddFriendRsp;
-import emu.grasscutter.server.packet.send.PacketDeleteFriendNotify;
-import emu.grasscutter.server.packet.send.PacketDeleteFriendRsp;
+import emu.grasscutter.server.packet.send.*;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+import java.util.List;
 
 public class FriendsList extends BasePlayerManager {
     private final Int2ObjectMap<Friendship> friends;
@@ -100,8 +96,8 @@ public class FriendsList extends BasePlayerManager {
 
         // Handle
         if (result == DealAddFriendResultType.DEAL_ADD_FRIEND_RESULT_TYPE_ACCEPT) { // Request accepted
-            myFriendship.setIsFriend(true);
-            theirFriendship.setIsFriend(true);
+            myFriendship.setFriend(true);
+            theirFriendship.setFriend(true);
 
             this.getPendingFriends().remove(myFriendship.getOwnerId());
             this.addFriend(myFriendship);

--- a/src/main/java/emu/grasscutter/game/friends/Friendship.java
+++ b/src/main/java/emu/grasscutter/game/friends/Friendship.java
@@ -1,109 +1,73 @@
 package emu.grasscutter.game.friends;
 
-import emu.grasscutter.net.proto.PlatformTypeOuterClass;
-import org.bson.types.ObjectId;
-
-import dev.morphia.annotations.*;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.annotations.Indexed;
+import dev.morphia.annotations.Transient;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.net.proto.FriendBriefOuterClass.FriendBrief;
-import emu.grasscutter.net.proto.FriendOnlineStateOuterClass.FriendOnlineState;
-import emu.grasscutter.net.proto.ProfilePictureOuterClass.ProfilePicture;
+import lombok.Getter;
+import lombok.Setter;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.FriendBrief;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.FriendOnlineState;
+import org.anime_game_servers.multi_proto.gi.messages.general.PlatformType;
+import org.anime_game_servers.multi_proto.gi.messages.general.ProfilePicture;
+import org.bson.types.ObjectId;
 
 @Entity(value = "friendships", useDiscriminator = false)
 public class Friendship {
-	@Id private ObjectId id;
-	
-	@Transient private Player owner;
-	
-	@Indexed private int ownerId;
-	@Indexed private int friendId;
-	private boolean isFriend;
-	private int askerId;
-	
-	private PlayerProfile profile;
-	
-	@Deprecated // Morphia use only
-	public Friendship() { }
-	
-	public Friendship(Player owner, Player friend, Player asker) {
-		this.setOwner(owner);
-		this.ownerId = owner.getUid();
-		this.friendId = friend.getUid();
-		this.profile = friend.getProfile();
-		this.askerId = asker.getUid();
-	}
+    @Id private ObjectId id;
+    @Getter @Setter @Transient private Player owner;
+    @Getter @Setter @Indexed private int ownerId;
+    @Getter @Setter @Indexed private int friendId;
+    @Getter @Setter private boolean isFriend;
+    @Getter @Setter private int askerId;
+    @Getter private PlayerProfile friendProfile;
 
-	public Player getOwner() {
-		return owner;
-	}
+    @Deprecated // Morphia use only
+    public Friendship() {
+    }
 
-	public void setOwner(Player owner) {
-		this.owner = owner;
-	}
+    public Friendship(Player owner, Player friend, Player asker) {
+        this.setOwner(owner);
+        this.ownerId = owner.getUid();
+        this.friendId = friend.getUid();
+        this.friendProfile = friend.getProfile();
+        this.askerId = asker.getUid();
+    }
 
-	public boolean isFriend() {
-		return isFriend;
-	}
+    public void setFriendProfile(Player character) {
+        if (character == null || this.friendId != character.getUid()) return;
+        this.friendProfile = character.getProfile();
+    }
 
-	public void setIsFriend(boolean b) {
-		this.isFriend = b;
-	}
+    public boolean isOnline() {
+        return getFriendProfile().getPlayer() != null;
+    }
 
-	public int getOwnerId() {
-		return ownerId;
-	}
+    public void save() {
+        DatabaseHelper.saveFriendship(this);
+    }
 
-	public int getFriendId() {
-		return friendId;
-	}
+    public void delete() {
+        DatabaseHelper.deleteFriendship(this);
+    }
 
-	public int getAskerId() {
-		return askerId;
-	}
-
-	public void setAskerId(int askerId) {
-		this.askerId = askerId;
-	}
-
-	public PlayerProfile getFriendProfile() {
-		return profile;
-	}
-	
-	public void setFriendProfile(Player character) {
-		if (character == null || this.friendId != character.getUid()) return;
-		this.profile = character.getProfile();
-	}
-	
-	public boolean isOnline() {
-		return getFriendProfile().getPlayer() != null;
-	}
-
-	public void save() {
-		DatabaseHelper.saveFriendship(this);
-	}
-
-	public void delete() {
-		DatabaseHelper.deleteFriendship(this);
-	}
-	
-	public FriendBrief toProto() {
-		FriendBrief proto = FriendBrief.newBuilder()
-				.setUid(getFriendProfile().getUid())
-				.setNickname(getFriendProfile().getName())
-				.setLevel(getFriendProfile().getPlayerLevel())
-				.setProfilePicture(ProfilePicture.newBuilder().setAvatarId(getFriendProfile().getAvatarId()))
-				.setWorldLevel(getFriendProfile().getWorldLevel())
-				.setSignature(getFriendProfile().getSignature())
-				.setOnlineState(getFriendProfile().isOnline() ? FriendOnlineState.FRIEND_ONLINE_STATE_ONLINE : FriendOnlineState.FRIEND_ONLINE_STATE_FREIEND_DISCONNECT)
-				.setIsMpModeAvailable(true)
-				.setLastActiveTime(getFriendProfile().getLastActiveTime())
-				.setNameCardId(getFriendProfile().getNameCard())
-				.setParam(getFriendProfile().getDaysSinceLogin())
-				.setIsGameSource(true)
-				.setPlatformType(PlatformTypeOuterClass.PlatformType.PLATFORM_TYPE_PC)
-				.build();
-
-		return proto;
-	}
+    public FriendBrief toProto() {
+        FriendBrief proto = new FriendBrief();
+        proto.setUid(getFriendProfile().getUid());
+        proto.setNickname(getFriendProfile().getName());
+        proto.setLevel(getFriendProfile().getPlayerLevel());
+        proto.setProfilePicture(new ProfilePicture(getFriendProfile().getAvatarId()));
+        proto.setWorldLevel(getFriendProfile().getWorldLevel());
+        proto.setSignature(getFriendProfile().getSignature());
+        proto.setOnlineState(getFriendProfile().isOnline() ? FriendOnlineState.FRIEND_ONLINE : FriendOnlineState.FRIEND_DISCONNECT);
+        proto.setMpModeAvailable(true);
+        proto.setLastActiveTime(getFriendProfile().getLastActiveTime());
+        proto.setNameCardId(getFriendProfile().getNameCard());
+        proto.setParam(getFriendProfile().getDaysSinceLogin());
+        proto.setGameSource(true);
+        proto.setPlatformType(PlatformType.PC);
+        return proto;
+    }
 }

--- a/src/main/java/emu/grasscutter/game/inventory/GameItem.java
+++ b/src/main/java/emu/grasscutter/game/inventory/GameItem.java
@@ -11,7 +11,7 @@ import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.entity.EntityWeapon;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.FightProperty;
-import emu.grasscutter.net.proto.ItemHintOuterClass.ItemHint;
+import org.anime_game_servers.multi_proto.gi.messages.item.ItemHint;
 import emu.grasscutter.net.proto.ItemParamOuterClass;
 import emu.grasscutter.utils.WeightedList;
 import lombok.Getter;
@@ -279,11 +279,12 @@ public class GameItem {
     }
 
     public ItemHint toItemHintProto() {
-        return ItemHint.newBuilder()
-            .setItemId(this.itemId)
-            .setCount(this.count)
-            .setIsNew(this.newItem)
-            .build();
+        ItemHint proto = new ItemHint();
+        proto.setCount(this.count);
+        proto.setNew(this.newItem);
+        proto.setItemId(this.itemId);
+        return proto;
+
     }
 
     public ItemParamOuterClass.ItemParam toItemParamOld() {

--- a/src/main/java/emu/grasscutter/game/player/PlayerCodex.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerCodex.java
@@ -11,6 +11,7 @@ import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.server.packet.send.PacketCodexDataUpdateNotify;
 import lombok.Getter;
 import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.codex.CodexType;
 
 import java.util.*;
 
@@ -57,7 +58,7 @@ public class PlayerCodex {
                     .ifPresent(codexData -> {
                         if (this.getUnlockedWeapon().add(itemId)) {
                             this.player.save();
-                            this.player.sendPacket(new PacketCodexDataUpdateNotify(2, codexData.getId()));
+                            this.player.sendPacket(new PacketCodexDataUpdateNotify(CodexType.CODEX_WEAPON, codexData.getId()));
                         }
                     });
             }
@@ -69,7 +70,7 @@ public class PlayerCodex {
                             .ifPresent(codexData -> {
                                 if (this.getUnlockedMaterial().add(itemId)) {
                                     this.player.save();
-                                    this.player.sendPacket(new PacketCodexDataUpdateNotify(4, codexData.getId()));
+                                    this.player.sendPacket(new PacketCodexDataUpdateNotify(CodexType.CODEX_MATERIAL, codexData.getId()));
                                 }
                             });
                     }
@@ -97,7 +98,7 @@ public class PlayerCodex {
             this.getUnlockedAnimal().merge(monsterId, 1, (i, j) -> i + 1);
 
             player.save();
-            this.player.sendPacket(new PacketCodexDataUpdateNotify(3, monsterId));
+            this.player.sendPacket(new PacketCodexDataUpdateNotify(CodexType.CODEX_ANIMAL, monsterId));
         }
     }
 
@@ -110,19 +111,19 @@ public class PlayerCodex {
                 int id = x.getId();
                 this.getUnlockedReliquarySuitCodex().add(id);
                 this.player.save();
-                this.player.sendPacket(new PacketCodexDataUpdateNotify(8, id));
+                this.player.sendPacket(new PacketCodexDataUpdateNotify(CodexType.CODEX_RELIQUARY, id));
             });
     }
 
     public void checkUnlockedViewPoints(CodexViewpointData viewpoint) {
         this.getUnlockedView().add(viewpoint.getId());
         this.player.save();
-        this.player.sendPacket(new PacketCodexDataUpdateNotify(7, viewpoint.getId()));
+        this.player.sendPacket(new PacketCodexDataUpdateNotify(CodexType.CODEX_VIEW, viewpoint.getId()));
     }
 
     public void checkBook(int bookId) {
         this.getUnlockedBook().add(bookId);
         this.player.save();
-        this.player.sendPacket(new PacketCodexDataUpdateNotify(5, bookId));
+        this.player.sendPacket(new PacketCodexDataUpdateNotify(CodexType.CODEX_BOOKS, bookId));
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -6,18 +6,18 @@ import dev.morphia.annotations.Indexed;
 import dev.morphia.annotations.Transient;
 import emu.grasscutter.Loggers;
 import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.binout.ScriptSceneData;
 import emu.grasscutter.data.common.quest.MainQuestData;
 import emu.grasscutter.data.common.quest.MainQuestData.TalkData;
-import emu.grasscutter.data.binout.ScriptSceneData;
 import emu.grasscutter.data.common.quest.SubQuestData;
 import emu.grasscutter.data.excels.RewardData;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActionReason;
-import emu.grasscutter.game.quest.enums.*;
+import emu.grasscutter.game.quest.enums.ParentQuestState;
+import emu.grasscutter.game.quest.enums.QuestCond;
+import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.game.world.World;
-import emu.grasscutter.net.proto.ChildQuestOuterClass.ChildQuest;
-import emu.grasscutter.net.proto.ParentQuestOuterClass.ParentQuest;
 import emu.grasscutter.server.packet.send.PacketCodexDataUpdateNotify;
 import emu.grasscutter.server.packet.send.PacketFinishedParentQuestUpdateNotify;
 import emu.grasscutter.server.packet.send.PacketQuestUpdateQuestVarNotify;
@@ -25,13 +25,14 @@ import emu.grasscutter.utils.Position;
 import emu.grasscutter.utils.Utils;
 import lombok.Getter;
 import lombok.val;
+import org.anime_game_servers.core.gi.enums.QuestState;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
+import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ParentQuest;
+import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ChildQuest;
 
 import javax.annotation.Nullable;
 import java.util.*;
-
-import org.anime_game_servers.core.gi.enums.QuestState;
 
 @Entity(value = "quests", useDiscriminator = false)
 public class GameMainQuest {
@@ -422,30 +423,25 @@ public class GameMainQuest {
     }
 
     public ParentQuest toProto(boolean withChildQuests) {
-        ParentQuest.Builder proto = ParentQuest.newBuilder()
-                .setParentQuestId(getParentQuestId())
-                .setIsFinished(isFinished())
-                .setParentQuestState(getState().getValue())
-                .setCutsceneEncryptionKey(QuestManager.getQuestKey(parentQuestId));
+        ParentQuest proto = new ParentQuest();
+        proto.setParentQuestId(getParentQuestId());
+        proto.setFinished(isFinished());
+        proto.setParentQuestState(getState().getValue());
+        proto.setVideoKey(QuestManager.getQuestKey(parentQuestId));
+
+
         if(withChildQuests) {
+            ArrayList<ChildQuest> childQuestList = new ArrayList<>();
             for (GameQuest quest : this.getChildQuests().values()) {
                 if (quest.getState() != QuestState.QUEST_STATE_UNSTARTED) {
-                    ChildQuest childQuest = ChildQuest.newBuilder()
-                        .setQuestId(quest.getSubQuestId())
-                        .setState(quest.getState().getValue())
-                        .build();
-
-                    proto.addChildQuestList(childQuest);
+                    childQuestList.add(new ChildQuest(quest.getSubQuestId(), quest.getState().getValue()));
                 }
             }
+            proto.setChildQuestList(childQuestList);
         }
 
-        for (int i : getQuestVars()) {
-            proto.addQuestVar(i);
-        }
-
-
-        return proto.build();
+        proto.setQuestVar(Arrays.stream(getQuestVars()).boxed().toList());
+        return proto;
     }
 
     // TimeVar handling TODO check if ingame or irl time

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -431,13 +431,10 @@ public class GameMainQuest {
 
 
         if(withChildQuests) {
-            ArrayList<ChildQuest> childQuestList = new ArrayList<>();
-            for (GameQuest quest : this.getChildQuests().values()) {
-                if (quest.getState() != QuestState.QUEST_STATE_UNSTARTED) {
-                    childQuestList.add(new ChildQuest(quest.getSubQuestId(), quest.getState().getValue()));
-                }
-            }
-            proto.setChildQuestList(childQuestList);
+            proto.setChildQuestList(this.getChildQuests().values().stream()
+                .filter(quest->quest.getState() != QuestState.QUEST_STATE_UNSTARTED)
+                .map(quest->new ChildQuest(quest.getSubQuestId(), quest.getState().getValue()))
+                .toList());
         }
 
         proto.setQuestVar(Arrays.stream(getQuestVars()).boxed().toList());

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -13,8 +13,6 @@ import emu.grasscutter.game.props.ActionReason;
 import emu.grasscutter.game.quest.enums.QuestCond;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.net.proto.ChapterStateOuterClass;
-import emu.grasscutter.net.proto.QuestOuterClass.Quest;
-
 import emu.grasscutter.server.packet.send.PacketChapterStateNotify;
 import emu.grasscutter.server.packet.send.PacketDelQuestNotify;
 import emu.grasscutter.server.packet.send.PacketQuestListUpdateNotify;
@@ -22,10 +20,12 @@ import emu.grasscutter.utils.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.Quest;
 import org.anime_game_servers.core.gi.enums.QuestState;
 
 import javax.annotation.Nullable;
 import javax.script.Bindings;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -262,26 +262,19 @@ public class GameQuest {
     }
 
     public Quest toProto() {
-        Quest.Builder proto = Quest.newBuilder()
-                .setQuestId(getSubQuestId())
-                .setState(getState().getValue())
-                .setParentQuestId(getMainQuestId())
-                .setStartTime(getStartTime())
-                .setStartGameTime(438)
-                .setAcceptTime(getAcceptTime());
+        Quest proto = new Quest(getSubQuestId(), getState().getValue(), getStartTime());
+        proto.setParentQuestId(getMainQuestId());
+        proto.setStartGameTime(438);
+        proto.setAcceptTime(getAcceptTime());
 
         if (getFinishProgressList() != null) {
-            for (int i : getFinishProgressList()) {
-                proto.addFinishProgressList(i);
-            }
+            proto.setFinishProgressList(Arrays.stream(getFinishProgressList()).boxed().toList());
         }
 
         if (getFailProgressList() != null) {
-            for (int i : getFailProgressList()) {
-                proto.addFailProgressList(i);
-            }
+            proto.setFailProgressList(Arrays.stream(getFailProgressList()).boxed().toList());
         }
 
-        return proto.build();
+        return proto;
     }
 }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -1,8 +1,5 @@
 package emu.grasscutter.scripts;
 
-import com.github.davidmoten.rtreemulti.RTree;
-import com.github.davidmoten.rtreemulti.geometry.Geometry;
-
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.Loggers;
 import emu.grasscutter.data.GameData;
@@ -17,7 +14,6 @@ import emu.grasscutter.game.quest.QuestGroupSuite;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.game.world.SceneGroupInstance;
-import emu.grasscutter.net.proto.VisionTypeOuterClass;
 import emu.grasscutter.scripts.lua_engine.GroupEventLuaContext;
 import emu.grasscutter.scripts.lua_engine.service.ScriptMonsterSpawnService;
 import emu.grasscutter.scripts.lua_engine.service.ScriptMonsterTideService;
@@ -31,8 +27,8 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import kotlin.Pair;
 import lombok.Getter;
 import lombok.val;
-import org.anime_game_servers.multi_proto.gi.messages.scene.VisionType;
-import org.anime_game_servers.gi_lua.models.*;
+import org.anime_game_servers.gi_lua.models.Position;
+import org.anime_game_servers.gi_lua.models.ScriptArgs;
 import org.anime_game_servers.gi_lua.models.constants.EventType;
 import org.anime_game_servers.gi_lua.models.constants.VisionLevelType;
 import org.anime_game_servers.gi_lua.models.scene.SceneConfig;
@@ -42,12 +38,12 @@ import org.anime_game_servers.gi_lua.models.scene.block.SceneGroupInfo;
 import org.anime_game_servers.gi_lua.models.scene.group.*;
 import org.anime_game_servers.lua.engine.LuaValue;
 import org.anime_game_servers.lua.models.BooleanLuaValue;
+import org.anime_game_servers.multi_proto.gi.messages.scene.VisionType;
 import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.script.ScriptException;
-
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -932,7 +928,7 @@ public class SceneScriptManager {
     }
 
     public void removeEntities(List<? extends GameEntity> gameEntity) {
-        getScene().removeEntities(gameEntity.stream().map(e -> (GameEntity) e).collect(Collectors.toList()), VisionTypeOuterClass.VisionType.VISION_TYPE_REFRESH);
+        getScene().removeEntities(gameEntity.stream().map(e -> (GameEntity) e).collect(Collectors.toList()), VisionType.VISION_REFRESH);
     }
 
     public void removeMonstersInGroup(SceneGroup group, SceneSuite suite) {
@@ -945,7 +941,7 @@ public class SceneScriptManager {
                 .filter(e -> configSet.contains(e.getConfigId()))
                 .toList();
 
-        getScene().removeEntities(toRemove, VisionTypeOuterClass.VisionType.VISION_TYPE_MISS);
+        getScene().removeEntities(toRemove, VisionType.VISION_MISS);
     }
     public void removeGadgetsInGroup(SceneGroup group, SceneSuite suite) {
         var configSet = suite.getSceneGadgets().stream()
@@ -957,7 +953,7 @@ public class SceneScriptManager {
                 .filter(e -> configSet.contains(e.getConfigId()))
                 .toList();
 
-        getScene().removeEntities(toRemove, VisionTypeOuterClass.VisionType.VISION_TYPE_MISS);
+        getScene().removeEntities(toRemove, VisionType.VISION_MISS);
     }
 
     public void killMonstersInGroup(SceneGroup group, SceneSuite suite) {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerAddQuestContentProgressReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerAddQuestContentProgressReq.java
@@ -1,21 +1,17 @@
 package emu.grasscutter.server.packet.recv;
 
 import emu.grasscutter.game.quest.enums.QuestContent;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketHandler;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AddQuestContentProgressReqOuterClass.AddQuestContentProgressReq;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketAddQuestContentProgressRsp;
 import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.AddQuestContentProgressReq;
 
 
-@Opcodes(PacketOpcodes.AddQuestContentProgressReq)
-public class HandlerAddQuestContentProgressReq extends PacketHandler {
+public class HandlerAddQuestContentProgressReq extends TypedPacketHandler<AddQuestContentProgressReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        var req = AddQuestContentProgressReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, AddQuestContentProgressReq req) throws Exception {
         //Find all conditions in quest that are the same as the given one
         val type = QuestContent.getContentTriggerByValue(req.getContentType());
         if(type!=null) {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerAskAddFriendReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerAskAddFriendReq.java
@@ -1,18 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AskAddFriendReqOuterClass.AskAddFriendReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.management.AskAddFriendReq;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 
-@Opcodes(PacketOpcodes.AskAddFriendReq)
-public class HandlerAskAddFriendReq extends PacketHandler {
-	
+public class HandlerAskAddFriendReq extends TypedPacketHandler<AskAddFriendReq> {
+
 	@Override
-	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-		AskAddFriendReq req = AskAddFriendReq.parseFrom(payload);
-		
+    public void handle(GameSession session, byte[] header, AskAddFriendReq req) throws Exception {
 		session.getPlayer().getFriendsList().sendFriendRequest(req.getTargetUid());
 	}
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerAvatarSkillUpgradeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerAvatarSkillUpgradeReq.java
@@ -1,18 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarSkillUpgradeReqOuterClass.AvatarSkillUpgradeReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
+import org.anime_game_servers.multi_proto.gi.messages.team.skill.AvatarSkillUpgradeReq;
 
-@Opcodes(PacketOpcodes.AvatarSkillUpgradeReq)
-public class HandlerAvatarSkillUpgradeReq extends PacketHandler {
+public class HandlerAvatarSkillUpgradeReq extends TypedPacketHandler<AvatarSkillUpgradeReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        AvatarSkillUpgradeReq req = AvatarSkillUpgradeReq.parseFrom(payload);
-
+    public void handle(GameSession session, byte[] header, AvatarSkillUpgradeReq req) throws Exception {
         // Sanity checks
         var avatar = session.getPlayer().getAvatars().getAvatarByGuid(req.getAvatarGuid());
         if (avatar == null) return;

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerAvatarUpgradeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerAvatarUpgradeReq.java
@@ -1,18 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarUpgradeReqOuterClass.AvatarUpgradeReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
+import org.anime_game_servers.multi_proto.gi.messages.team.avatar.upgrade.AvatarUpgradeReq;
 
-@Opcodes(PacketOpcodes.AvatarUpgradeReq)
-public class HandlerAvatarUpgradeReq extends PacketHandler {
+public class HandlerAvatarUpgradeReq extends TypedPacketHandler<AvatarUpgradeReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        AvatarUpgradeReq req = AvatarUpgradeReq.parseFrom(payload);
-
+    public void handle(GameSession session, byte[] header, AvatarUpgradeReq req) throws Exception {
         // Level up avatar
         session.getServer().getInventorySystem().upgradeAvatar(
                 session.getPlayer(),

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerChangeAvatarReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerChangeAvatarReq.java
@@ -1,19 +1,14 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.ChangeAvatarReqOuterClass.ChangeAvatarReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketChangeAvatarRsp;
+import org.anime_game_servers.multi_proto.gi.messages.team.avatar.ChangeAvatarReq;
 
-@Opcodes(PacketOpcodes.ChangeAvatarReq)
-public class HandlerChangeAvatarReq extends PacketHandler {
+public class HandlerChangeAvatarReq extends TypedPacketHandler<ChangeAvatarReq> {
 
 	@Override
-	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-		ChangeAvatarReq req = ChangeAvatarReq.parseFrom(payload);
-
+    public void handle(GameSession session, byte[] header, ChangeAvatarReq req) throws Exception {
         session.getPlayer().sendPacket(new PacketChangeAvatarRsp(
             session.getPlayer().getTeamManager().changeAvatar(req.getGuid()),
             req.getGuid()

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtAiSyncCombatThreatInfoNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtAiSyncCombatThreatInfoNotify.java
@@ -1,15 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
+import org.anime_game_servers.multi_proto.gi.messages.battle.event.EvtAiSyncCombatThreatInfoNotify;
 
-@Opcodes(PacketOpcodes.EvtAiSyncCombatThreatInfoNotify)
-public class HandlerEvtAiSyncCombatThreatInfoNotify extends PacketHandler {
-	
+public class HandlerEvtAiSyncCombatThreatInfoNotify extends TypedPacketHandler<EvtAiSyncCombatThreatInfoNotify> {
+
 	@Override
-	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+    public void handle(GameSession session, byte[] header, EvtAiSyncCombatThreatInfoNotify req) throws Exception {
 		// Auto template
 	}
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerAskFriendListReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerAskFriendListReq.java
@@ -1,15 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketHandler;
-import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketGetPlayerAskFriendListRsp;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.GetPlayerAskFriendListReq;
 
-@Opcodes(PacketOpcodes.GetPlayerAskFriendListReq)
-public class HandlerGetPlayerAskFriendListReq extends PacketHandler {
+public class HandlerGetPlayerAskFriendListReq extends TypedPacketHandler<GetPlayerAskFriendListReq> {
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+    public void handle(GameSession session, byte[] header, GetPlayerAskFriendListReq req) throws Exception {
         session.send(new PacketGetPlayerAskFriendListRsp(session.getPlayer()));
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerFriendListReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerFriendListReq.java
@@ -1,15 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketGetPlayerFriendListRsp;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.GetPlayerFriendListReq;
 
-@Opcodes(PacketOpcodes.GetPlayerFriendListReq)
-public class HandlerGetPlayerFriendListReq extends PacketHandler {
+public class HandlerGetPlayerFriendListReq extends TypedPacketHandler<GetPlayerFriendListReq> {
 	@Override
-	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+    public void handle(GameSession session, byte[] header, GetPlayerFriendListReq req) throws Exception {
 		//session.send(new PacketGetPlayerAskFriendListRsp(session.getPlayer()));
 		session.send(new PacketGetPlayerFriendListRsp(session.getPlayer()));
 	}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetScenePointReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetScenePointReq.java
@@ -1,20 +1,14 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.GetScenePointReqOuterClass.GetScenePointReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketGetScenePointRsp;
+import org.anime_game_servers.multi_proto.gi.messages.scene.GetScenePointReq;
 
-@Opcodes(PacketOpcodes.GetScenePointReq)
-public class HandlerGetScenePointReq extends PacketHandler {
+public class HandlerGetScenePointReq extends TypedPacketHandler<GetScenePointReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        GetScenePointReq req = GetScenePointReq.parseFrom(payload);
-
+    public void handle(GameSession session, byte[] header, GetScenePointReq req) throws Exception {
         session.send(new PacketGetScenePointRsp(session.getPlayer(), req.getSceneId()));
     }
-
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPingReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPingReq.java
@@ -1,24 +1,18 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.PacketHeadOuterClass.PacketHead;
-import emu.grasscutter.net.proto.PingReqOuterClass.PingReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketPingRsp;
+import org.anime_game_servers.multi_proto.gi.messages.other.PingReq;
 
-@Opcodes(PacketOpcodes.PingReq)
-public class HandlerPingReq extends PacketHandler {
-	
-	@Override
-	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-		PacketHead head = PacketHead.parseFrom(header);
-		PingReq ping = PingReq.parseFrom(payload);
-		
-		session.updateLastPingTime(ping.getClientTime());
-		
-		session.send(new PacketPingRsp(head.getClientSequenceId(), ping.getClientTime()));
-	}
+public class HandlerPingReq extends TypedPacketHandler<PingReq> {
+
+    @Override
+    public void handle(GameSession session, byte[] header, PingReq req) throws Exception {
+        PacketHead head = PacketHead.parseFrom(header);
+        session.updateLastPingTime(req.getClientTime());
+        session.send(new PacketPingRsp(head.getClientSequenceId(), req.getClientTime()));
+    }
 
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerSetPauseReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerSetPauseReq.java
@@ -1,21 +1,15 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.PacketHeadOuterClass.PacketHead;
-import emu.grasscutter.net.proto.PlayerSetPauseReqOuterClass.PlayerSetPauseReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketPlayerSetPauseRsp;
+import org.anime_game_servers.multi_proto.gi.messages.player.PlayerSetPauseReq;
 
-@Opcodes(PacketOpcodes.PlayerSetPauseReq)
-public class HandlerPlayerSetPauseReq extends PacketHandler {
+public class HandlerPlayerSetPauseReq extends TypedPacketHandler<PlayerSetPauseReq> {
 
 	@Override
-	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-		PlayerSetPauseReq req = PlayerSetPauseReq.parseFrom(payload);
-        session.getPlayer().getWorld().setPaused(req.getIsPaused());
-
+    public void handle(GameSession session, byte[] header, PlayerSetPauseReq req) throws Exception {
+        session.getPlayer().getWorld().setPaused(req.isPaused());
 		session.send(new PacketPlayerSetPauseRsp());
 	}
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestCreateEntityReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestCreateEntityReq.java
@@ -5,57 +5,49 @@ import emu.grasscutter.data.excels.GadgetData;
 import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.data.excels.MonsterData;
 import emu.grasscutter.game.entity.*;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketQuestCreateEntityRsp;
 import emu.grasscutter.utils.Position;
 import lombok.val;
-import emu.grasscutter.net.proto.QuestCreateEntityReqOuterClass.QuestCreateEntityReq;
+import org.anime_game_servers.multi_proto.gi.messages.general.entity.CreateEntityInfo.Entity.GadgetId;
+import org.anime_game_servers.multi_proto.gi.messages.general.entity.CreateEntityInfo.Entity.ItemId;
+import org.anime_game_servers.multi_proto.gi.messages.general.entity.CreateEntityInfo.Entity.MonsterId;
+import org.anime_game_servers.multi_proto.gi.messages.general.entity.CreateEntityInfo.Entity.NpcId;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestCreateEntityReq;
 
-@Opcodes(PacketOpcodes.QuestCreateEntityReq)
-public class HandlerQuestCreateEntityReq extends PacketHandler {
+public class HandlerQuestCreateEntityReq extends TypedPacketHandler<QuestCreateEntityReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        val req = QuestCreateEntityReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, QuestCreateEntityReq req) throws Exception {
         val entity = req.getEntity();
         val scene = session.getPlayer().getWorld().getSceneById(entity.getSceneId());
 
         val pos = new Position(entity.getPos());
         val rot = new Position(entity.getRot());
         GameEntity gameEntity = null;
-        switch (entity.getEntityCase()){
-            case GADGET_ID -> {
-                val gadgetId = entity.getGadgetId();
-                val gadgetInfo = entity.getGadget();
-                GadgetData gadgetData = GameData.getGadgetDataMap().get(gadgetId);
-                gameEntity = switch (gadgetData.getType()){
-                    case Vehicle -> new EntityVehicle(scene, session.getPlayer(), gadgetId, 0, pos, rot);
-                    default -> new EntityGadget(scene, gadgetId, pos, rot);
-                };
-            }
-            case ITEM_ID -> {
-                val itemId = entity.getItemId();
-                ItemData itemData = GameData.getItemDataMap().get(itemId);
-                gameEntity = new EntityItem(scene, null, itemData, pos, 1, true);
-            }
-            case MONSTER_ID -> {
-                val monsterId = entity.getMonsterId();
-                val level = entity.getLevel();
-                MonsterData monsterData = GameData.getMonsterDataMap().get(monsterId);
-                gameEntity = new EntityMonster(scene, monsterData, pos, level);
-            }
-            case NPC_ID -> {
-            }
+        if (entity.getEntity() instanceof GadgetId gadgetId) {
+            GadgetData gadgetData = GameData.getGadgetDataMap().get((int) gadgetId.getValue());
+            gameEntity = switch (gadgetData.getType()) {
+                case Vehicle -> new EntityVehicle(scene, session.getPlayer(), gadgetId.getValue(), 0, pos, rot);
+                default -> new EntityGadget(scene, gadgetId.getValue(), pos, rot);
+            };
+        } else if (entity.getEntity() instanceof ItemId itemId) {
+            ItemData itemData = GameData.getItemDataMap().get((int) itemId.getValue());
+            gameEntity = new EntityItem(scene, null, itemData, pos, 1, true);
+        } else if (entity.getEntity() instanceof MonsterId monsterId) {
+            val level = entity.getLevel();
+            MonsterData monsterData = GameData.getMonsterDataMap().get((int) monsterId.getValue());
+            gameEntity = new EntityMonster(scene, monsterData, pos, level);
+        } else if (entity.getEntity() instanceof NpcId npcId) {
+            //nothing
         }
 
-        if(gameEntity != null){
+        if (gameEntity != null) {
             scene.addEntity(gameEntity);
         }
 
-        val createdEntityId = gameEntity!=null ? gameEntity.getId() : -1;
+        val createdEntityId = gameEntity != null ? gameEntity.getId() : -1;
 
         session.send(new PacketQuestCreateEntityRsp(createdEntityId, req));
     }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestDestroyEntityReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestDestroyEntityReq.java
@@ -1,19 +1,15 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketQuestDestroyEntityRsp;
 import lombok.val;
-import emu.grasscutter.net.proto.QuestDestroyEntityReqOuterClass.QuestDestroyEntityReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestDestroyEntityReq;
 
-@Opcodes(PacketOpcodes.QuestDestroyEntityReq)
-public class HandlerQuestDestroyEntityReq extends PacketHandler {
+public class HandlerQuestDestroyEntityReq extends TypedPacketHandler<QuestDestroyEntityReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        val req = QuestDestroyEntityReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, QuestDestroyEntityReq req) throws Exception {
         val scene = session.getPlayer().getWorld().getSceneById(req.getSceneId());
         val entity = scene.getEntityById(req.getEntityId());
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestDestroyNpcReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestDestroyNpcReq.java
@@ -1,20 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.game.entity.EntityNPC;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketQuestDestroyNpcRsp;
-import lombok.val;
-import emu.grasscutter.net.proto.QuestDestroyNpcReqOuterClass.QuestDestroyNpcReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestDestroyNpcReq;
 
-@Opcodes(PacketOpcodes.QuestDestroyNpcReq)
-public class HandlerQuestDestroyNpcReq extends PacketHandler {
+public class HandlerQuestDestroyNpcReq extends TypedPacketHandler<QuestDestroyNpcReq> {
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        val req = QuestDestroyNpcReq.parseFrom(payload);
-
+    public void handle(GameSession session, byte[] header, QuestDestroyNpcReq req) throws Exception {
         session.send(new PacketQuestDestroyNpcRsp(req.getNpcId(), req.getParentQuestId(), 0));
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestTransmitReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuestTransmitReq.java
@@ -2,28 +2,23 @@ package emu.grasscutter.server.packet.recv;
 
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.quest.GameQuest;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketHandler;
-import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.event.player.PlayerTeleportEvent.TeleportType;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketQuestTransmitRsp;
 import emu.grasscutter.utils.Position;
-import emu.grasscutter.net.proto.QuestTransmitReqOuterClass.QuestTransmitReq;
-
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Optional;
-
 import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestTransmitReq;
 import org.anime_game_servers.gi_lua.models.quest.QuestData;
 
-@Opcodes(PacketOpcodes.QuestTransmitReq)
-public class HandlerQuestTransmitReq extends PacketHandler {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class HandlerQuestTransmitReq extends TypedPacketHandler<QuestTransmitReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        val req = QuestTransmitReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, QuestTransmitReq req) throws Exception {
         val player = session.getPlayer();
         val posAndRot = new ArrayList<Position>();
         final int sceneId = Optional.ofNullable(GameData.getTeleportDataMap().get(req.getQuestId()))

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSceneEntityDrownReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSceneEntityDrownReq.java
@@ -4,27 +4,21 @@ import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.props.FightProperty;
-import emu.grasscutter.game.props.LifeState;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketHandler;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.SceneEntityDrownReqOuterClass.SceneEntityDrownReq;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketSceneEntityDrownRsp;
+import org.anime_game_servers.multi_proto.gi.messages.scene.entity.SceneEntityDrownReq;
 
-@Opcodes(PacketOpcodes.SceneEntityDrownReq)
-public class HandlerSceneEntityDrownReq extends PacketHandler {
+public class HandlerSceneEntityDrownReq extends TypedPacketHandler<SceneEntityDrownReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        SceneEntityDrownReq req = SceneEntityDrownReq.parseFrom(payload);
-
+    public void handle(GameSession session, byte[] header, SceneEntityDrownReq req) throws Exception {
         GameEntity entity = session.getPlayer().getScene().getEntityById(req.getEntityId());
 
         if (entity == null || !(entity instanceof EntityMonster || entity instanceof EntityAvatar)) {
-        	return;
+            return;
         }
-        
+
         entity.setFightProperty(FightProperty.FIGHT_PROP_CUR_HP, 0);
 
         //TODO: make a list somewhere of all entities to remove per tick rather than one by one

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSceneTransToPointReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSceneTransToPointReq.java
@@ -2,23 +2,19 @@ package emu.grasscutter.server.packet.recv;
 
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.ScenePointEntry;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.SceneTransToPointReqOuterClass.SceneTransToPointReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.event.player.PlayerTeleportEvent.TeleportType;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketSceneTransToPointRsp;
 import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.scene.SceneTransToPointReq;
 
 import java.util.Optional;
 
-@Opcodes(PacketOpcodes.SceneTransToPointReq)
-public class HandlerSceneTransToPointReq extends PacketHandler {
+public class HandlerSceneTransToPointReq extends TypedPacketHandler<SceneTransToPointReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        val req = SceneTransToPointReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, SceneTransToPointReq req) throws Exception {
         val player = session.getPlayer();
         val result = Optional.ofNullable(GameData.getScenePointEntryById(req.getSceneId(), req.getPointId()))
             .map(ScenePointEntry::getPointData)

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
@@ -1,32 +1,24 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.GameConstants;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.commands.SendMailCommand.MailBuilder;
 import emu.grasscutter.data.GameData;
-import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.mail.Mail;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.SetPlayerBornDataReqOuterClass.SetPlayerBornDataReq;
-import emu.grasscutter.net.packet.PacketHandler;
-import emu.grasscutter.server.event.game.PlayerCreationEvent;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
-import emu.grasscutter.server.game.GameSession.SessionState;
-
-import static emu.grasscutter.config.Configuration.*;
+import org.anime_game_servers.multi_proto.gi.messages.player.SetPlayerBornDataReq;
 
 import java.util.Arrays;
 
-@Opcodes(PacketOpcodes.SetPlayerBornDataReq)
-public class HandlerSetPlayerBornDataReq extends PacketHandler {
+import static emu.grasscutter.config.Configuration.GAME_INFO;
+
+public class HandlerSetPlayerBornDataReq extends TypedPacketHandler<SetPlayerBornDataReq> {
 
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        SetPlayerBornDataReq req = SetPlayerBornDataReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, SetPlayerBornDataReq req) throws Exception {
 
         // Sanity checks
         int avatarId = req.getAvatarId();

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnionCmdNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnionCmdNotify.java
@@ -3,6 +3,7 @@ package emu.grasscutter.server.packet.recv;
 import emu.grasscutter.Grasscutter.ServerDebugMode;
 import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
+import lombok.val;
 import org.anime_game_servers.multi_proto.gi.messages.other.UnionCmd;
 import org.anime_game_servers.multi_proto.gi.messages.other.UnionCmdNotify;
 
@@ -16,10 +17,11 @@ public class HandlerUnionCmdNotify extends TypedPacketHandler<UnionCmdNotify> {
 
         for (UnionCmd cmd : req.getCmdList()) {
             int cmdOpcode = cmd.getMessageId();
+            val cmdName = session.getPackageIdProvider().getPacketName(cmdOpcode);
             byte[] cmdPayload = cmd.getBody();
-            if (GAME_INFO.logPackets == ServerDebugMode.WHITELIST && SERVER.debugWhitelist.contains(String.valueOf(cmd.getMessageId()))) {
+            if (GAME_INFO.logPackets == ServerDebugMode.WHITELIST && SERVER.debugWhitelist.contains(cmdName)) {
                 session.logPacket("RECV in Union", cmdOpcode, cmdPayload);
-            } else if (GAME_INFO.logPackets ==  ServerDebugMode.BLACKLIST && !SERVER.debugBlacklist.contains(String.valueOf(cmd.getMessageId()))) {
+            } else if (GAME_INFO.logPackets ==  ServerDebugMode.BLACKLIST && !SERVER.debugBlacklist.contains(cmdName)) {
                 session.logPacket("RECV in Union", cmdOpcode, cmdPayload);
             }
             //debugLevel ALL ignores UnionCmdNotify, so we will also ignore the contained opcodes

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnionCmdNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnionCmdNotify.java
@@ -1,31 +1,29 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.Grasscutter.ServerDebugMode;
+import emu.grasscutter.net.packet.TypedPacketHandler;
+import emu.grasscutter.server.game.GameSession;
+import org.anime_game_servers.multi_proto.gi.messages.other.UnionCmd;
+import org.anime_game_servers.multi_proto.gi.messages.other.UnionCmdNotify;
+
 import static emu.grasscutter.config.Configuration.GAME_INFO;
 import static emu.grasscutter.config.Configuration.SERVER;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.UnionCmdNotifyOuterClass.UnionCmdNotify;
-import emu.grasscutter.net.proto.UnionCmdOuterClass.UnionCmd;
-import emu.grasscutter.net.packet.PacketHandler;
-import emu.grasscutter.server.game.GameSession;
-import emu.grasscutter.Grasscutter.ServerDebugMode;
 
-@Opcodes(PacketOpcodes.UnionCmdNotify)
-public class HandlerUnionCmdNotify extends PacketHandler {
+public class HandlerUnionCmdNotify extends TypedPacketHandler<UnionCmdNotify> {
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        UnionCmdNotify req = UnionCmdNotify.parseFrom(payload);
-        for (UnionCmd cmd : req.getCmdListList()) {
+    public void handle(GameSession session, byte[] header, UnionCmdNotify req) throws Exception {
+
+        for (UnionCmd cmd : req.getCmdList()) {
             int cmdOpcode = cmd.getMessageId();
-            byte[] cmdPayload = cmd.getBody().toByteArray();
-            if (GAME_INFO.logPackets == ServerDebugMode.WHITELIST && SERVER.debugWhitelist.contains(cmd.getMessageId())) {
+            byte[] cmdPayload = cmd.getBody();
+            if (GAME_INFO.logPackets == ServerDebugMode.WHITELIST && SERVER.debugWhitelist.contains(String.valueOf(cmd.getMessageId()))) {
                 session.logPacket("RECV in Union", cmdOpcode, cmdPayload);
-            } else if (GAME_INFO.logPackets ==  ServerDebugMode.BLACKLIST && !SERVER.debugBlacklist.contains(cmd.getMessageId())) {
+            } else if (GAME_INFO.logPackets ==  ServerDebugMode.BLACKLIST && !SERVER.debugBlacklist.contains(String.valueOf(cmd.getMessageId()))) {
                 session.logPacket("RECV in Union", cmdOpcode, cmdPayload);
             }
             //debugLevel ALL ignores UnionCmdNotify, so we will also ignore the contained opcodes
-            session.getServer().getPacketHandler().handle(session, cmd.getMessageId(), EMPTY_BYTE_ARRAY, cmd.getBody().toByteArray());
+            session.getServer().getPacketHandler().handle(session, cmd.getMessageId(), EMPTY_BYTE_ARRAY, cmd.getBody());
         }
 
         // Update

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnlockTransPointReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnlockTransPointReq.java
@@ -1,19 +1,14 @@
 package emu.grasscutter.server.packet.recv;
 
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.RetcodeOuterClass;
-import emu.grasscutter.net.proto.UnlockTransPointReqOuterClass.UnlockTransPointReq;
-import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.TypedPacketHandler;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketUnlockTransPointRsp;
+import org.anime_game_servers.multi_proto.gi.messages.scene.UnlockTransPointReq;
 
-@Opcodes(PacketOpcodes.UnlockTransPointReq)
-public class HandlerUnlockTransPointReq extends PacketHandler {
+public class HandlerUnlockTransPointReq extends TypedPacketHandler<UnlockTransPointReq> {
     @Override
-    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        UnlockTransPointReq req = UnlockTransPointReq.parseFrom(payload);
+    public void handle(GameSession session, byte[] header, UnlockTransPointReq req) throws Exception {
         boolean unlocked = session.getPlayer().getProgressManager().unlockTransPoint(req.getSceneId(), req.getPointId(), false);
-        session.getPlayer().sendPacket(new PacketUnlockTransPointRsp(unlocked ? RetcodeOuterClass.Retcode.RET_SUCC : RetcodeOuterClass.Retcode.RET_FAIL));
+        session.getPlayer().sendPacket(new PacketUnlockTransPointRsp(unlocked));
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAddQuestContentProgressRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAddQuestContentProgressRsp.java
@@ -1,19 +1,12 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AddQuestContentProgressRspOuterClass;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.AddQuestContentProgressRsp;
 
-public class PacketAddQuestContentProgressRsp extends BasePacket {
+public class PacketAddQuestContentProgressRsp extends BaseTypedPacket<AddQuestContentProgressRsp> {
 
 	public PacketAddQuestContentProgressRsp(int contentType) {
-		super(PacketOpcodes.AddQuestContentProgressRsp);
-
-        var proto = AddQuestContentProgressRspOuterClass.AddQuestContentProgressRsp.newBuilder();
-
+        super(new AddQuestContentProgressRsp());
         proto.setContentType(contentType);
-
-        this.setData(proto);
-
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAskAddFriendNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAskAddFriendNotify.java
@@ -1,20 +1,14 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.friends.Friendship;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AskAddFriendNotifyOuterClass.AskAddFriendNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.management.AskAddFriendNotify;
 
-public class PacketAskAddFriendNotify extends BasePacket {
-	
+public class PacketAskAddFriendNotify extends BaseTypedPacket<AskAddFriendNotify> {
+
 	public PacketAskAddFriendNotify(Friendship friendship) {
-		super(PacketOpcodes.AskAddFriendNotify);
-
-		AskAddFriendNotify proto = AskAddFriendNotify.newBuilder()
-				.setTargetUid(friendship.getFriendId())
-				.setTargetFriendBrief(friendship.toProto())
-				.build();
-		
-		this.setData(proto);
+        super(new AskAddFriendNotify());
+        proto.setTargetUid(friendship.getFriendId());
+        proto.setTargetFriendBrief(friendship.toProto());
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAskAddFriendRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAskAddFriendRsp.java
@@ -1,18 +1,12 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AskAddFriendRspOuterClass.AskAddFriendRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.management.AskAddFriendRsp;
 
-public class PacketAskAddFriendRsp extends BasePacket {
-	
+public class PacketAskAddFriendRsp extends BaseTypedPacket<AskAddFriendRsp> {
+
 	public PacketAskAddFriendRsp(int targetUid) {
-		super(PacketOpcodes.AskAddFriendRsp);
-		
-		AskAddFriendRsp proto = AskAddFriendRsp.newBuilder()
-				.setTargetUid(targetUid)
-				.build();
-		
-		this.setData(proto);
+        super(new AskAddFriendRsp());
+        proto.setTargetUid(targetUid);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillChangeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillChangeNotify.java
@@ -1,24 +1,18 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarSkillChangeNotifyOuterClass.AvatarSkillChangeNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.team.skill.AvatarSkillChangeNotify;
 
-public class PacketAvatarSkillChangeNotify extends BasePacket {
-	
-	public PacketAvatarSkillChangeNotify(Avatar avatar, int skillId, int oldLevel, int curLevel) {
-		super(PacketOpcodes.AvatarSkillChangeNotify);
-		
-		AvatarSkillChangeNotify proto = AvatarSkillChangeNotify.newBuilder()
-				.setAvatarGuid(avatar.getGuid())
-				.setEntityId(avatar.getEntityId())
-				.setSkillDepotId(avatar.getSkillDepotId())
-				.setAvatarSkillId(skillId)
-				.setOldLevel(oldLevel)
-				.setCurLevel(curLevel)
-				.build();
-		
-		this.setData(proto);
-	}
+public class PacketAvatarSkillChangeNotify extends BaseTypedPacket<AvatarSkillChangeNotify> {
+
+    public PacketAvatarSkillChangeNotify(Avatar avatar, int skillId, int oldLevel, int curLevel) {
+        super(new AvatarSkillChangeNotify());
+        proto.setAvatarGuid(avatar.getGuid());
+        proto.setEntityId(avatar.getEntityId());
+        proto.setSkillDepotId(avatar.getSkillDepotId());
+        proto.setAvatarSkillId(skillId);
+        proto.setOldLevel(oldLevel);
+        proto.setCurLevel(curLevel);
+    }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillDepotChangeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillDepotChangeNotify.java
@@ -1,26 +1,21 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarSkillDepotChangeNotifyOuterClass.AvatarSkillDepotChangeNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.team.skill.AvatarSkillDepotChangeNotify;
 
-public class PacketAvatarSkillDepotChangeNotify extends BasePacket {
-	
-	public PacketAvatarSkillDepotChangeNotify(Avatar avatar) {
-		super(PacketOpcodes.AvatarSkillDepotChangeNotify);
-		
-		AvatarSkillDepotChangeNotify proto = AvatarSkillDepotChangeNotify.newBuilder()
-				.setAvatarGuid(avatar.getGuid())
-				.setEntityId(avatar.getEntityId())
-				.setSkillDepotId(avatar.getSkillDepotId())
-				.setCoreProudSkillLevel(avatar.getCoreProudSkillLevel())
-				.addAllTalentIdList(avatar.getTalentIdList())
-				.addAllProudSkillList(avatar.getProudSkillList())
-				.putAllSkillLevelMap(avatar.getSkillLevelMap())
-				.putAllProudSkillExtraLevelMap(avatar.getProudSkillBonusMap())
-				.build();
-		
-		this.setData(proto);
-	}
+import java.util.ArrayList;
+
+public class PacketAvatarSkillDepotChangeNotify extends BaseTypedPacket<AvatarSkillDepotChangeNotify> {
+    public PacketAvatarSkillDepotChangeNotify(Avatar avatar) {
+        super(new AvatarSkillDepotChangeNotify());
+        proto.setAvatarGuid(avatar.getGuid());
+        proto.setEntityId(avatar.getEntityId());
+        proto.setSkillDepotId(avatar.getSkillDepotId());
+        proto.setTalentIdList(new ArrayList<>(avatar.getTalentIdList()));
+        proto.setProudSkillList(new ArrayList<>(avatar.getProudSkillList()));
+        proto.setCoreProudSkillLevel(avatar.getCoreProudSkillLevel());
+        proto.setSkillLevelMap(avatar.getSkillLevelMap());
+        proto.setProudSkillExtraLevelMap(avatar.getProudSkillBonusMap());
+    }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillInfoNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillInfoNotify.java
@@ -1,20 +1,23 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarSkillInfoNotifyOuterClass.AvatarSkillInfoNotify;
-import emu.grasscutter.net.proto.AvatarSkillInfoOuterClass.AvatarSkillInfo;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import org.anime_game_servers.multi_proto.gi.messages.general.avatar.AvatarSkillInfo;
+import org.anime_game_servers.multi_proto.gi.messages.team.skill.AvatarSkillInfoNotify;
 
-public class PacketAvatarSkillInfoNotify extends BasePacket {
+import java.util.HashMap;
+import java.util.Map;
+
+public class PacketAvatarSkillInfoNotify extends BaseTypedPacket<AvatarSkillInfoNotify> {
     public PacketAvatarSkillInfoNotify(long avatarGuid, Int2IntMap skillExtraChargeMap) {
-        super(PacketOpcodes.AvatarSkillInfoNotify);
-
-        var proto = AvatarSkillInfoNotify.newBuilder().setGuid(avatarGuid);
-
-        skillExtraChargeMap.forEach((skillId, count) ->
-            proto.putSkillMap(skillId, AvatarSkillInfo.newBuilder().setMaxChargeCount(count).build()));
-
-        this.setData(proto);
+        super(new AvatarSkillInfoNotify());
+        proto.setGuid(avatarGuid);
+        Map<Integer, AvatarSkillInfo> AvatarSkillInfoMap = new HashMap<>();
+        skillExtraChargeMap.forEach((skillId, count) -> {
+            var AvatarSkill = new AvatarSkillInfo();
+            AvatarSkill.setMaxChargeCount(count);
+            AvatarSkillInfoMap.put(skillId, AvatarSkill);
+        });
+        proto.setSkillMap(AvatarSkillInfoMap);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillMaxChargeCountNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillMaxChargeCountNotify.java
@@ -1,21 +1,15 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarSkillMaxChargeCountNotifyOuterClass.AvatarSkillMaxChargeCountNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.team.skill.AvatarSkillMaxChargeCountNotify;
 
-public class PacketAvatarSkillMaxChargeCountNotify extends BasePacket {
-	
+public class PacketAvatarSkillMaxChargeCountNotify extends BaseTypedPacket<AvatarSkillMaxChargeCountNotify> {
+
 	public PacketAvatarSkillMaxChargeCountNotify(Avatar avatar, int skillId, int maxCharges) {
-		super(PacketOpcodes.AvatarSkillMaxChargeCountNotify);
-
-		AvatarSkillMaxChargeCountNotify proto = AvatarSkillMaxChargeCountNotify.newBuilder()
-				.setAvatarGuid(avatar.getGuid())
-				.setSkillId(skillId)
-				.setMaxChargeCount(maxCharges)
-				.build();
-		
-		this.setData(proto);
+        super(new AvatarSkillMaxChargeCountNotify());
+        proto.setAvatarGuid(avatar.getGuid());
+        proto.setSkillId(skillId);
+        proto.setMaxChargeCount(maxCharges);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillUpgradeRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarSkillUpgradeRsp.java
@@ -1,22 +1,16 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarSkillUpgradeRspOuterClass.AvatarSkillUpgradeRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.team.skill.AvatarSkillUpgradeRsp;
 
-public class PacketAvatarSkillUpgradeRsp extends BasePacket {
-	
+public class PacketAvatarSkillUpgradeRsp extends BaseTypedPacket<AvatarSkillUpgradeRsp> {
+
 	public PacketAvatarSkillUpgradeRsp(Avatar avatar, int skillId, int oldLevel, int newLevel) {
-		super(PacketOpcodes.AvatarSkillUpgradeRsp);
-
-		AvatarSkillUpgradeRsp proto = AvatarSkillUpgradeRsp.newBuilder()
-				.setAvatarGuid(avatar.getGuid())
-				.setAvatarSkillId(skillId)
-				.setOldLevel(oldLevel)
-				.setCurLevel(newLevel)
-				.build();
-		
-		this.setData(proto);
+        super(new AvatarSkillUpgradeRsp());
+        proto.setAvatarGuid(avatar.getGuid());
+        proto.setAvatarSkillId(skillId);
+        proto.setOldLevel(oldLevel);
+        proto.setCurLevel(newLevel);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarUpgradeRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarUpgradeRsp.java
@@ -1,27 +1,20 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.game.avatar.Avatar;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.team.avatar.upgrade.AvatarUpgradeRsp;
+
 import java.util.Map;
 
-import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.AvatarUpgradeRspOuterClass.AvatarUpgradeRsp;
+public class PacketAvatarUpgradeRsp extends BaseTypedPacket<AvatarUpgradeRsp> {
 
-public class PacketAvatarUpgradeRsp extends BasePacket {
-	
 	public PacketAvatarUpgradeRsp(Avatar avatar, int oldLevel, Map<Integer, Float> oldFightPropMap) {
-		super(PacketOpcodes.AvatarUpgradeRsp);
-		
+        super(new AvatarUpgradeRsp());
 		this.buildHeader(0);
-
-		AvatarUpgradeRsp proto = AvatarUpgradeRsp.newBuilder()
-				.setAvatarGuid(avatar.getGuid())
-				.setOldLevel(oldLevel)
-				.setCurLevel(avatar.getLevel())
-				.putAllOldFightPropMap(oldFightPropMap)
-				.putAllCurFightPropMap(avatar.getFightProperties())
-				.build();
-		
-		this.setData(proto);
+        proto.setAvatarGuid(avatar.getGuid());
+        proto.setOldLevel(oldLevel);
+        proto.setCurLevel(avatar.getLevel());
+        proto.setOldFightPropMap(oldFightPropMap);
+        proto.setCurFightPropMap(avatar.getFightProperties());
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketChangeAvatarRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketChangeAvatarRsp.java
@@ -1,19 +1,14 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.ChangeAvatarRspOuterClass.ChangeAvatarRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.team.avatar.ChangeAvatarRsp;
 
-public class PacketChangeAvatarRsp extends BasePacket {
+public class PacketChangeAvatarRsp extends BaseTypedPacket<ChangeAvatarRsp> {
 
 	public PacketChangeAvatarRsp(int ret, long guid) {
-		super(PacketOpcodes.ChangeAvatarRsp);
+        super(new ChangeAvatarRsp());
+        proto.setRetcode(ret);
+        proto.setCurGuid(guid);
 
-		ChangeAvatarRsp p = ChangeAvatarRsp.newBuilder()
-				.setRetcode(ret)
-				.setCurGuid(guid)
-				.build();
-
-		this.setData(p);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketCodexDataUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketCodexDataUpdateNotify.java
@@ -2,29 +2,22 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.quest.GameMainQuest;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.CodexDataUpdateNotifyOuterClass.CodexDataUpdateNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.codex.CodexDataUpdateNotify;
+import org.anime_game_servers.multi_proto.gi.messages.codex.CodexType;
 
-public class PacketCodexDataUpdateNotify extends BasePacket {
+public class PacketCodexDataUpdateNotify extends BaseTypedPacket<CodexDataUpdateNotify> {
     public PacketCodexDataUpdateNotify(GameMainQuest quest) {
-        super(PacketOpcodes.CodexDataUpdateNotify, true);
+        super(new CodexDataUpdateNotify(), true);
         var codexQuest = GameData.getCodexQuestDataIdMap().get(quest.getParentQuestId());
-        if(codexQuest != null){
-            CodexDataUpdateNotify proto = CodexDataUpdateNotify.newBuilder()
-                    .setTypeValue(1)
-                    .setId(codexQuest.getId())
-                    .build();
-            this.setData(proto);
-        }
+        if (codexQuest == null) return;
+        proto.setType(CodexType.CODEX_QUEST);
+        proto.setId(codexQuest.getId());
     }
 
-    public PacketCodexDataUpdateNotify(int typeValue, int codexId){
-        super(PacketOpcodes.CodexDataUpdateNotify, true);
-        CodexDataUpdateNotify proto = CodexDataUpdateNotify.newBuilder()
-                .setTypeValue(typeValue)
-                .setId(codexId)
-                .build();
-        this.setData(proto);
+    public PacketCodexDataUpdateNotify(CodexType codexType, int codexId) {
+        super(new CodexDataUpdateNotify(), true);
+        proto.setType(codexType);
+        proto.setId(codexId);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketDelQuestNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketDelQuestNotify.java
@@ -1,21 +1,13 @@
 package emu.grasscutter.server.packet.send;
 
-import java.util.List;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.QuestDelNotify;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestDelNotifyOuterClass.QuestDelNotify;
-
-public class PacketDelQuestNotify extends BasePacket {
+public class PacketDelQuestNotify extends BaseTypedPacket<QuestDelNotify> {
 
 	public PacketDelQuestNotify(int questId) {
-		super(PacketOpcodes.QuestDelNotify);
-
-        QuestDelNotify proto = QuestDelNotify.newBuilder()
-				.setQuestId(questId)
-				.build();
-
-		this.setData(proto);
+        super(new QuestDelNotify());
+        proto.setQuestId(questId);
 	}
 
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEntityFightPropUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEntityFightPropUpdateNotify.java
@@ -2,32 +2,26 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.props.FightProperty;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.EntityFightPropUpdateNotifyOuterClass.EntityFightPropUpdateNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.entity.EntityFightPropUpdateNotify;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
-public class PacketEntityFightPropUpdateNotify extends BasePacket {
+public class PacketEntityFightPropUpdateNotify extends BaseTypedPacket<EntityFightPropUpdateNotify> {
 
 	public PacketEntityFightPropUpdateNotify(GameEntity entity, FightProperty prop) {
-		super(PacketOpcodes.EntityFightPropUpdateNotify);
-
-		EntityFightPropUpdateNotify proto = EntityFightPropUpdateNotify.newBuilder()
-				.setEntityId(entity.getId())
-				.putFightPropMap(prop.getId(), entity.getFightProperty(prop))
-				.build();
-
-		this.setData(proto);
+        super(new EntityFightPropUpdateNotify());
+        proto.setEntityId(entity.getId());
+        proto.setFightPropMap(Map.of(prop.getId(), entity.getFightProperty(prop)));
 	}
 
     public PacketEntityFightPropUpdateNotify(GameEntity entity, Collection<FightProperty> props) {
-		super(PacketOpcodes.EntityFightPropUpdateNotify);
-
-		var protoBuilder = EntityFightPropUpdateNotify.newBuilder()
-				.setEntityId(entity.getId());
-        props.forEach(p -> protoBuilder.putFightPropMap(p.getId(), entity.getFightProperty(p)));
-
-		this.setData(protoBuilder);
+        super(new EntityFightPropUpdateNotify());
+        proto.setEntityId(entity.getId());
+        Map<Integer, Float> fightPropMap = new HashMap<>();
+        props.forEach(p -> fightPropMap.put(p.getId(), entity.getFightProperty(p)));
+        proto.setFightPropMap(fightPropMap);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketFinishedParentQuestNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketFinishedParentQuestNotify.java
@@ -1,26 +1,18 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.game.quest.GameMainQuest;
 import emu.grasscutter.game.quest.enums.ParentQuestState;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.FinishedParentQuestNotifyOuterClass.FinishedParentQuestNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.parent.FinishedParentQuestNotify;
 
-public class PacketFinishedParentQuestNotify extends BasePacket {
+public class PacketFinishedParentQuestNotify extends BaseTypedPacket<FinishedParentQuestNotify> {
 
     public PacketFinishedParentQuestNotify(Player player) {
-        super(PacketOpcodes.FinishedParentQuestNotify, true);
-
-        FinishedParentQuestNotify.Builder proto = FinishedParentQuestNotify.newBuilder();
-
-        for (GameMainQuest mainQuest : player.getQuestManager().getMainQuests().values()) {
+        super(new FinishedParentQuestNotify(), true);
+        proto.setParentQuestList(player.getQuestManager().getMainQuests().values().stream()
             //Canceled Quests do not appear in this packet
-            if (mainQuest.getState() != ParentQuestState.PARENT_QUEST_STATE_CANCELED) {
-                proto.addParentQuestList(mainQuest.toProto(false));
-            }
-        }
-
-        this.setData(proto);
+            .filter(mainQuest -> mainQuest.getState() != ParentQuestState.PARENT_QUEST_STATE_CANCELED)
+            .map(mainQuest -> mainQuest.toProto(false))
+            .toList());
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketFinishedParentQuestUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketFinishedParentQuestUpdateNotify.java
@@ -1,33 +1,19 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.quest.GameMainQuest;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.FinishedParentQuestUpdateNotifyOuterClass.FinishedParentQuestUpdateNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.parent.FinishedParentQuestUpdateNotify;
 
 import java.util.List;
 
-public class PacketFinishedParentQuestUpdateNotify extends BasePacket {
+public class PacketFinishedParentQuestUpdateNotify extends BaseTypedPacket<FinishedParentQuestUpdateNotify> {
 
     public PacketFinishedParentQuestUpdateNotify(GameMainQuest quest) {
-        super(PacketOpcodes.FinishedParentQuestUpdateNotify);
-
-        FinishedParentQuestUpdateNotify proto = FinishedParentQuestUpdateNotify.newBuilder()
-                .addParentQuestList(quest.toProto(true))
-                .build();
-
-        this.setData(proto);
+        this(List.of(quest));
     }
 
     public PacketFinishedParentQuestUpdateNotify(List<GameMainQuest> quests) {
-        super(PacketOpcodes.FinishedParentQuestUpdateNotify);
-
-        var proto = FinishedParentQuestUpdateNotify.newBuilder();
-
-        for (GameMainQuest mainQuest : quests) {
-            proto.addParentQuestList(mainQuest.toProto(true));
-        }
-        proto.build();
-        this.setData(proto);
+        super(new FinishedParentQuestUpdateNotify());
+        proto.setParentQuestList(quests.stream().map(mainQuest -> mainQuest.toProto(true)).toList());
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGetPlayerAskFriendListRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGetPlayerAskFriendListRsp.java
@@ -2,24 +2,17 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.friends.Friendship;
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.GetPlayerAskFriendListRspOuterClass.GetPlayerAskFriendListRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.community.friends.GetPlayerAskFriendListRsp;
 
-public class PacketGetPlayerAskFriendListRsp extends BasePacket {
-	
+public class PacketGetPlayerAskFriendListRsp extends BaseTypedPacket<GetPlayerAskFriendListRsp> {
+
 	public PacketGetPlayerAskFriendListRsp(Player player) {
-		super(PacketOpcodes.GetPlayerAskFriendListRsp);
-		
-		GetPlayerAskFriendListRsp.Builder proto = GetPlayerAskFriendListRsp.newBuilder();
+        super(new GetPlayerAskFriendListRsp());
 
-		for (Friendship friendship : player.getFriendsList().getPendingFriends().values()) {
-			if (friendship.getAskerId() == player.getUid()) {
-				continue;
-			}
-			proto.addAskFriendList(friendship.toProto());
-		}
-		
-		this.setData(proto);
+        proto.setAskFriendList(player.getFriendsList().getPendingFriends().values().stream()
+            .filter(friendship -> friendship.getAskerId() != player.getUid())
+            .map(Friendship::toProto)
+            .toList());
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGetScenePointRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGetScenePointRsp.java
@@ -2,31 +2,26 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.GetScenePointRspOuterClass.GetScenePointRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.scene.GetScenePointRsp;
 
 import java.util.HashSet;
 import java.util.Set;
 
-public class PacketGetScenePointRsp extends BasePacket {
+public class PacketGetScenePointRsp extends BaseTypedPacket<GetScenePointRsp> {
     private static final Set<Integer> bruteForceScenePointIdList = buildBruteForceScenePointIdList();
 
     public PacketGetScenePointRsp(Player player, int sceneId) {
-        super(PacketOpcodes.GetScenePointRsp);
-
+        super(new GetScenePointRsp());
         val unlockedAreaList = player.getUnlockedSceneAreas(sceneId);
         val scenePointIdList = GameData.getScenePointIdList().isEmpty() ? bruteForceScenePointIdList :
             player.getUnlockedScenePoints(sceneId);
-
-        val proto = GetScenePointRsp.newBuilder()
-            .setSceneId(sceneId)
-            .addAllUnhidePointList(scenePointIdList)
-            .addAllUnlockedPointList(scenePointIdList)
-            .addAllUnlockAreaList(unlockedAreaList);
-
-        this.setData(proto);
+        proto.setSceneId(sceneId);
+        proto.setUnhidePointList(scenePointIdList.stream().toList());
+        proto.setUnlockedPointList(scenePointIdList.stream().toList());
+        proto.setUnlockAreaList(unlockedAreaList.stream().toList());
+        ;
     }
 
     private static Set<Integer> buildBruteForceScenePointIdList() {

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGroupSuiteNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGroupSuiteNotify.java
@@ -2,51 +2,40 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.data.binout.SceneNpcBornEntry;
 import emu.grasscutter.game.quest.QuestGroupSuite;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.GroupSuiteNotifyOuterClass;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.group.GroupSuiteNotify;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public class PacketGroupSuiteNotify extends BasePacket {
+public class PacketGroupSuiteNotify extends BaseTypedPacket<GroupSuiteNotify> {
 
 	/**
 	 * Real control which npc suite is loaded
      * EntityNPC is useless
 	 */
 	public PacketGroupSuiteNotify(List<SceneNpcBornEntry> npcBornEntries) {
-		super(PacketOpcodes.GroupSuiteNotify);
-
-		var proto = GroupSuiteNotifyOuterClass.GroupSuiteNotify.newBuilder();
-
+        super(new GroupSuiteNotify());
+        Map<Integer, Integer> groupMap = new HashMap<>();
         npcBornEntries.stream()
             .filter(x -> x.getGroupId() > 0 && x.getSuiteIdList() != null)
             .forEach(x -> x.getSuiteIdList().forEach(y ->
-                proto.putGroupMap(x.getGroupId(), y)
+                groupMap.put(x.getGroupId(), y) //TODO: this only saves one value of y??
             ));
-
-		this.setData(proto);
-
+        proto.setGroupMap(groupMap);
 	}
 
     public PacketGroupSuiteNotify(int groupId, int suiteId) {
-        super(PacketOpcodes.GroupSuiteNotify);
-
-        var proto = GroupSuiteNotifyOuterClass.GroupSuiteNotify.newBuilder();
-
-        proto.putGroupMap(groupId, suiteId);
-
-        this.setData(proto);
+        super(new GroupSuiteNotify());
+        proto.setGroupMap(Map.of(groupId, suiteId));
     }
 
     public PacketGroupSuiteNotify(Collection<QuestGroupSuite> questGroupSuites) {
-        super(PacketOpcodes.GroupSuiteNotify);
-
-        var proto = GroupSuiteNotifyOuterClass.GroupSuiteNotify.newBuilder();
-
-        questGroupSuites.forEach(i -> proto.putGroupMap(i.getGroup(), i.getSuite()));
-
-        this.setData(proto);
+        super(new GroupSuiteNotify());
+        Map<Integer, Integer> groupMap = new HashMap<>();
+        questGroupSuites.forEach(i -> groupMap.put(i.getGroup(), i.getSuite()));
+        proto.setGroupMap(groupMap);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGroupUnloadNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGroupUnloadNotify.java
@@ -1,20 +1,14 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.GroupUnloadNotifyOuterClass;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.group.GroupUnloadNotify;
 
 import java.util.List;
 
-public class PacketGroupUnloadNotify extends BasePacket {
+public class PacketGroupUnloadNotify extends BaseTypedPacket<GroupUnloadNotify> {
 
 	public PacketGroupUnloadNotify(List<Integer> groupList) {
-		super(PacketOpcodes.GroupUnloadNotify);
-
-        var proto = GroupUnloadNotifyOuterClass.GroupUnloadNotify.newBuilder();
-
-        proto.addAllGroupList(groupList);
-
-        this.setData(proto);
+        super(new GroupUnloadNotify());
+        proto.setGroupList(groupList);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketItemAddHintNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketItemAddHintNotify.java
@@ -1,37 +1,24 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.game.inventory.GameItem;
+import emu.grasscutter.game.props.ActionReason;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.item.ItemAddHintNotify;
+
 import java.util.Collection;
 import java.util.List;
 
-import emu.grasscutter.game.inventory.GameItem;
-import emu.grasscutter.game.props.ActionReason;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.ItemAddHintNotifyOuterClass.ItemAddHintNotify;
+public class PacketItemAddHintNotify extends BaseTypedPacket<ItemAddHintNotify> {
 
-public class PacketItemAddHintNotify extends BasePacket {
-	
 	public PacketItemAddHintNotify(GameItem item, ActionReason reason) {
-		super(PacketOpcodes.ItemAddHintNotify);
-		
-		ItemAddHintNotify proto = ItemAddHintNotify.newBuilder()
-				.addItemList(item.toItemHintProto())
-				.setReason(reason.getValue())
-				.build();
-		
-		this.setData(proto);
+        super(new ItemAddHintNotify());
+        proto.setItemList(List.of(item.toItemHintProto()));
+        proto.setReason(reason.getValue());
 	}
 
 	public PacketItemAddHintNotify(Collection<GameItem> items, ActionReason reason) {
-		super(PacketOpcodes.ItemAddHintNotify);
-		
-		ItemAddHintNotify.Builder proto = ItemAddHintNotify.newBuilder()
-				.setReason(reason.getValue());
-		
-		for (GameItem item : items) {
-			proto.addItemList(item.toItemHintProto());
-		}
-		
-		this.setData(proto);
+        super(new ItemAddHintNotify());
+        proto.setItemList(items.stream().map(GameItem::toItemHintProto).toList());
+        proto.setReason(reason.getValue());
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPingRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPingRsp.java
@@ -1,18 +1,12 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.PingRspOuterClass.PingRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.other.PingRsp;
 
-public class PacketPingRsp extends BasePacket {
+public class PacketPingRsp extends BaseTypedPacket<PingRsp> {
 
 	public PacketPingRsp(int clientSeq, int time) {
-		super(PacketOpcodes.PingRsp, clientSeq);
-		
-		PingRsp p = PingRsp.newBuilder()
-				.setClientTime(time)
-				.build();
-		
-		this.setData(p.toByteArray());
+        super(new PingRsp(), clientSeq);
+        proto.setClientTime(time);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerPropChangeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerPropChangeNotify.java
@@ -2,23 +2,15 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.PlayerProperty;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.PlayerPropChangeNotifyOuterClass.PlayerPropChangeNotify;
-import emu.grasscutter.utils.ProtoHelper;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.player.PlayerPropChangeNotify;
 
-public class PacketPlayerPropChangeNotify extends BasePacket {
+public class PacketPlayerPropChangeNotify extends BaseTypedPacket<PlayerPropChangeNotify> {
 
     public PacketPlayerPropChangeNotify(Player player, PlayerProperty prop, int delta) {
-        super(PacketOpcodes.PlayerPropChangeNotify);
-
+        super(new PlayerPropChangeNotify());
         this.buildHeader(0);
-
-        PlayerPropChangeNotify proto = PlayerPropChangeNotify.newBuilder()
-                .setPropType(prop.getId())
-                .setPropDelta(delta)
-                .build();
-
-        this.setData(proto);
+        proto.setPropType(prop.getId());
+        proto.setPropDelta(delta);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerSetPauseRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerSetPauseRsp.java
@@ -1,17 +1,13 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.PlayerSetPauseRspOuterClass.PlayerSetPauseRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import emu.grasscutter.net.proto.RetcodeOuterClass;
+import org.anime_game_servers.multi_proto.gi.messages.player.PlayerSetPauseRsp;
 
-public class PacketPlayerSetPauseRsp extends BasePacket {
+public class PacketPlayerSetPauseRsp extends BaseTypedPacket<PlayerSetPauseRsp> {
 
 	public PacketPlayerSetPauseRsp() {
-		super(PacketOpcodes.PlayerSetPauseRsp);
-
-
-		this.setData(PlayerSetPauseRsp.newBuilder()
-            .setRetcode(RetcodeOuterClass.Retcode.RET_SUCC_VALUE));
+        super(new PlayerSetPauseRsp());
+        proto.setRetcode(RetcodeOuterClass.Retcode.RET_SUCC_VALUE);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestCreateEntityRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestCreateEntityRsp.java
@@ -1,23 +1,20 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
-import emu.grasscutter.net.proto.QuestCreateEntityReqOuterClass.QuestCreateEntityReq;
-import emu.grasscutter.net.proto.QuestCreateEntityRspOuterClass.QuestCreateEntityRsp;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestCreateEntityReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestCreateEntityRsp;
 
-public class PacketQuestCreateEntityRsp extends BasePacket {
+public class PacketQuestCreateEntityRsp extends BaseTypedPacket<QuestCreateEntityRsp> {
 
 	public PacketQuestCreateEntityRsp(int entityId, QuestCreateEntityReq req) {
-		super(PacketOpcodes.QuestCreateEntityRsp);
-
-        this.setData(QuestCreateEntityRsp.newBuilder()
-            .setQuestId(req.getQuestId())
-            .setEntity(req.getEntity())
-            .setParentQuestId(req.getParentQuestId())
-            .setIsRewind(req.getIsRewind())
-            .setEntityId(entityId).setRetcode(
-                entityId!=-1 ? Retcode.RET_SUCC_VALUE : Retcode.RET_FAIL_VALUE));
+        super(new QuestCreateEntityRsp());
+        proto.setEntityId(entityId);
+        proto.setEntity(req.getEntity());
+        proto.setQuestId(req.getQuestId());
+        proto.setRewind(req.isRewind());
+        proto.setParentQuestId(req.getParentQuestId());
+        proto.setRetCode(entityId != -1 ? Retcode.RET_SUCC_VALUE : Retcode.RET_FAIL_VALUE);
 	}
 
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestDestroyEntityRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestDestroyEntityRsp.java
@@ -1,21 +1,18 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
-import emu.grasscutter.net.proto.QuestDestroyEntityRspOuterClass.QuestDestroyEntityRsp;
-import emu.grasscutter.net.proto.QuestDestroyEntityReqOuterClass.QuestDestroyEntityReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestDestroyEntityReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestDestroyEntityRsp;
 
-public class PacketQuestDestroyEntityRsp extends BasePacket {
+public class PacketQuestDestroyEntityRsp extends BaseTypedPacket<QuestDestroyEntityRsp> {
 
 	public PacketQuestDestroyEntityRsp(boolean success, QuestDestroyEntityReq req) {
-		super(PacketOpcodes.QuestDestroyEntityRsp);
-
-        this.setData(QuestDestroyEntityRsp.newBuilder()
-            .setQuestId(req.getQuestId())
-            .setEntityId(req.getEntityId())
-            .setSceneId(req.getSceneId())
-            .setRetcode(success ? Retcode.RET_SUCC_VALUE : Retcode.RET_FAIL_VALUE));
+        super(new QuestDestroyEntityRsp());
+        proto.setEntityId(req.getEntityId());
+        proto.setQuestId(req.getQuestId());
+        proto.setSceneId(req.getSceneId());
+        proto.setRetCode(success ? Retcode.RET_SUCC_VALUE : Retcode.RET_FAIL_VALUE);
 	}
 
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestDestroyNpcRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestDestroyNpcRsp.java
@@ -1,20 +1,14 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestDestroyNpcRspOuterClass.QuestDestroyNpcRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestDestroyNpcRsp;
 
-public class PacketQuestDestroyNpcRsp extends BasePacket {
+public class PacketQuestDestroyNpcRsp extends BaseTypedPacket<QuestDestroyNpcRsp> {
 
     public PacketQuestDestroyNpcRsp(int npcId, int parentQuestId, int retCode) {
-        super(PacketOpcodes.QuestDestroyNpcRsp, true);
-
-        QuestDestroyNpcRsp proto = QuestDestroyNpcRsp.newBuilder()
-            .setNpcId(npcId)
-            .setParentQuestId(parentQuestId)
-            .setRetcode(retCode)
-            .build();
-
-        this.setData(proto);
+        super(new QuestDestroyNpcRsp(), true);
+        proto.setNpcId(npcId);
+        proto.setParentQuestId(parentQuestId);
+        proto.setRetCode(retCode);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestListNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestListNotify.java
@@ -1,24 +1,25 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestListNotifyOuterClass.QuestListNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.Quest;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.QuestListNotify;
 import org.anime_game_servers.core.gi.enums.QuestState;
 
-public class PacketQuestListNotify extends BasePacket {
+import java.util.ArrayList;
+import java.util.List;
+
+public class PacketQuestListNotify extends BaseTypedPacket<QuestListNotify> {
 
     public PacketQuestListNotify(Player player) {
-        super(PacketOpcodes.QuestListNotify, true);
+        super(new QuestListNotify(), true);
 
-        QuestListNotify.Builder proto = QuestListNotify.newBuilder();
-
+        List<Quest> questList = new ArrayList<>();
         player.getQuestManager().forEachQuest(quest -> {
             if (quest.getState() != QuestState.QUEST_STATE_UNSTARTED) {
-                proto.addQuestList(quest.toProto());
+                questList.add(quest.toProto());
             }
         });
-
-        this.setData(proto);
+        proto.setQuestList(questList);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestListUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestListUpdateNotify.java
@@ -1,33 +1,19 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.game.quest.GameMainQuest;
 import emu.grasscutter.game.quest.GameQuest;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestListUpdateNotifyOuterClass.QuestListUpdateNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.QuestListUpdateNotify;
 
 import java.util.List;
 
-public class PacketQuestListUpdateNotify extends BasePacket {
+public class PacketQuestListUpdateNotify extends BaseTypedPacket<QuestListUpdateNotify> {
 
     public PacketQuestListUpdateNotify(GameQuest quest) {
-        super(PacketOpcodes.QuestListUpdateNotify);
-
-        QuestListUpdateNotify proto = QuestListUpdateNotify.newBuilder()
-                .addQuestList(quest.toProto())
-                .build();
-
-        this.setData(proto);
+        this(List.of(quest));
     }
 
     public PacketQuestListUpdateNotify(List<GameQuest> quests) {
-        super(PacketOpcodes.QuestListUpdateNotify);
-        var proto = QuestListUpdateNotify.newBuilder();
-        for (GameQuest quest : quests) {
-            proto.addQuestList(quest.toProto());
-        }
-        proto.build();
-
-        this.setData(proto);
+        super(new QuestListUpdateNotify());
+        proto.setQuestList(quests.stream().map(GameQuest::toProto).toList());
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestProgressUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestProgressUpdateNotify.java
@@ -1,30 +1,23 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.game.quest.GameMainQuest;
 import emu.grasscutter.game.quest.GameQuest;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestProgressUpdateNotifyOuterClass.QuestProgressUpdateNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.child.QuestProgressUpdateNotify;
 
-public class PacketQuestProgressUpdateNotify extends BasePacket {
+import java.util.Arrays;
+
+public class PacketQuestProgressUpdateNotify extends BaseTypedPacket<QuestProgressUpdateNotify> {
 
     public PacketQuestProgressUpdateNotify(GameQuest quest) {
-        super(PacketOpcodes.QuestProgressUpdateNotify);
-
-        QuestProgressUpdateNotify.Builder proto = QuestProgressUpdateNotify.newBuilder().setQuestId(quest.getSubQuestId());
+        super(new QuestProgressUpdateNotify());
+        proto.setQuestId(quest.getSubQuestId());
 
         if (quest.getFinishProgressList() != null) {
-            for (int i : quest.getFinishProgressList()) {
-                proto.addFinishProgressList(i);
-            }
+            proto.setFinishProgressList(Arrays.stream(quest.getFinishProgressList()).boxed().toList());
         }
 
         if (quest.getFailProgressList() != null) {
-            for (int i : quest.getFailProgressList()) {
-                proto.addFailProgressList(i);
-            }
+            proto.setFailProgressList(Arrays.stream(quest.getFailProgressList()).boxed().toList());
         }
-
-        this.setData(proto);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestTransmitRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestTransmitRsp.java
@@ -1,18 +1,16 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
-import emu.grasscutter.net.proto.QuestTransmitRspOuterClass.QuestTransmitRsp;
-import emu.grasscutter.net.proto.QuestTransmitReqOuterClass.QuestTransmitReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestTransmitReq;
+import org.anime_game_servers.multi_proto.gi.messages.quest.entities.QuestTransmitRsp;
 
-public class PacketQuestTransmitRsp extends BasePacket {
+public class PacketQuestTransmitRsp extends BaseTypedPacket<QuestTransmitRsp> {
 
 	public PacketQuestTransmitRsp(boolean result, QuestTransmitReq req) {
-		super(PacketOpcodes.QuestTransmitRsp);
-		this.setData(QuestTransmitRsp.newBuilder()
-			.setQuestId(req.getQuestId())
-			.setPointId(req.getPointId())
-			.setRetcode(result ? Retcode.RET_SUCC_VALUE : Retcode.RET_FAIL_VALUE));
+        super(new QuestTransmitRsp());
+        proto.setPointId(req.getPointId());
+        proto.setQuestId(req.getQuestId());
+        proto.setRetCode(result ? Retcode.RET_SUCC_VALUE : Retcode.RET_FAIL_VALUE);
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestUpdateQuestVarNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestUpdateQuestVarNotify.java
@@ -1,21 +1,15 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestUpdateQuestVarNotifyOuterClass.QuestUpdateQuestVarNotify;
-import lombok.val;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.variable.QuestUpdateQuestVarNotify;
 
 import java.util.stream.IntStream;
 
-@Opcodes(PacketOpcodes.QuestUpdateQuestVarNotify)
-public class PacketQuestUpdateQuestVarNotify extends BasePacket {
+public class PacketQuestUpdateQuestVarNotify extends BaseTypedPacket<QuestUpdateQuestVarNotify> {
 
     public PacketQuestUpdateQuestVarNotify(int mainQuestId, int... questVars) {
-        super(PacketOpcodes.QuestUpdateQuestVarNotify);
-        val questVarList = IntStream.of(questVars).boxed().toList();
-        this.setData(QuestUpdateQuestVarNotify.newBuilder()
-            .setParentQuestId(mainQuestId)
-            .addAllQuestVar(questVarList));
+        super(new QuestUpdateQuestVarNotify());
+        proto.setParentQuestId(mainQuestId);
+        proto.setQuestVar(IntStream.of(questVars).boxed().toList());
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketQuestUpdateQuestVarRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketQuestUpdateQuestVarRsp.java
@@ -1,26 +1,20 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.Opcodes;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.QuestUpdateQuestVarReqOuterClass.QuestUpdateQuestVarReq;
-import emu.grasscutter.net.proto.QuestUpdateQuestVarRspOuterClass;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.variable.QuestUpdateQuestVarReq;
 import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
+import org.anime_game_servers.multi_proto.gi.messages.quest.variable.QuestUpdateQuestVarRsp;
 
-@Opcodes(PacketOpcodes.QuestUpdateQuestVarReq)
-public class PacketQuestUpdateQuestVarRsp extends BasePacket {
+public class PacketQuestUpdateQuestVarRsp extends BaseTypedPacket<QuestUpdateQuestVarRsp> {
 
     public PacketQuestUpdateQuestVarRsp(QuestUpdateQuestVarReq req) {
         this(req, Retcode.RET_SUCC);
     }
 
     public PacketQuestUpdateQuestVarRsp(QuestUpdateQuestVarReq req, Retcode retcode) {
-        super(PacketOpcodes.QuestUpdateQuestVarRsp);
-        var rsp = QuestUpdateQuestVarRspOuterClass.QuestUpdateQuestVarRsp.newBuilder()
-            .setQuestId(req.getQuestId())
-            .setParentQuestId(req.getParentQuestId())
-            .setRetcode(retcode.getNumber())
-            .build();
-        this.setData(rsp);
+        super(new QuestUpdateQuestVarRsp());
+        proto.setQuestId(req.getQuestId());
+        proto.setParentQuestId(req.getParentQuestId());
+        proto.setRetCode(retcode.getNumber());
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketSceneEntityDisappearNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketSceneEntityDisappearNotify.java
@@ -1,35 +1,25 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.game.entity.GameEntity;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.VisionType;
+import org.anime_game_servers.multi_proto.gi.messages.scene.entity.SceneEntityDisappearNotify;
+
 import java.util.Collection;
 import java.util.List;
 
-import emu.grasscutter.game.entity.GameEntity;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.SceneEntityDisappearNotifyOuterClass.SceneEntityDisappearNotify;
-import emu.grasscutter.net.proto.VisionTypeOuterClass.VisionType;
 
-public class PacketSceneEntityDisappearNotify extends BasePacket {
-	
+public class PacketSceneEntityDisappearNotify extends BaseTypedPacket<SceneEntityDisappearNotify> {
+
 	public PacketSceneEntityDisappearNotify(GameEntity entity, VisionType disappearType) {
-		super(PacketOpcodes.SceneEntityDisappearNotify);
-
-		SceneEntityDisappearNotify proto = SceneEntityDisappearNotify.newBuilder()
-				.setDisappearType(disappearType)
-				.addEntityList(entity.getId())
-				.build();
-
-		this.setData(proto);
+        super(new SceneEntityDisappearNotify());
+        proto.setDisappearType(disappearType);
+        proto.setEntityList(List.of(entity.getId()));
 	}
-	
+
 	public PacketSceneEntityDisappearNotify(Collection<GameEntity> entities, VisionType disappearType) {
-		super(PacketOpcodes.SceneEntityDisappearNotify);
-
-		SceneEntityDisappearNotify.Builder proto = SceneEntityDisappearNotify.newBuilder()
-				.setDisappearType(disappearType);
-		
-		entities.forEach(e -> proto.addEntityList(e.getId()));
-
-		this.setData(proto);
+        super(new SceneEntityDisappearNotify());
+        proto.setDisappearType(disappearType);
+        proto.setEntityList(entities.stream().map(GameEntity::getId).toList());
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketSceneEntityDrownRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketSceneEntityDrownRsp.java
@@ -1,17 +1,13 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.SceneEntityDrownRspOuterClass.SceneEntityDrownRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.entity.SceneEntityDrownRsp;
 
-public class PacketSceneEntityDrownRsp extends BasePacket {
+public class PacketSceneEntityDrownRsp extends BaseTypedPacket<SceneEntityDrownRsp> {
 
     public PacketSceneEntityDrownRsp(int entityId) {
-        super(PacketOpcodes.SceneEntityDrownRsp);
-
-        SceneEntityDrownRsp proto = SceneEntityDrownRsp.newBuilder().setEntityId(entityId).build();
-
-        this.setData(proto);
+        super(new SceneEntityDrownRsp());
+        proto.setEntityId(entityId);
     }
 }
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketScenePointUnlockNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketScenePointUnlockNotify.java
@@ -1,26 +1,25 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.ScenePointUnlockNotifyOuterClass.ScenePointUnlockNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.ScenePointUnlockNotify;
 
-public class PacketScenePointUnlockNotify extends BasePacket {
+import java.util.ArrayList;
+import java.util.List;
+
+public class PacketScenePointUnlockNotify extends BaseTypedPacket<ScenePointUnlockNotify> {
     public PacketScenePointUnlockNotify(int sceneId, int pointId) {
         this(sceneId, pointId, false);
     }
 
     public PacketScenePointUnlockNotify(int sceneId, int pointId, boolean lock) {
-        super(PacketOpcodes.ScenePointUnlockNotify);
-
-        ScenePointUnlockNotify.Builder p = ScenePointUnlockNotify.newBuilder()
-                .setSceneId(sceneId)
-                .addPointList(pointId);
-        if(lock)
-            p.addLockedPointList(pointId);
-        else
-            p.addUnhidePointList(pointId);
-
-        this.setData(p);
+        super(new ScenePointUnlockNotify());
+        proto.setSceneId(sceneId);
+        proto.setPointList(List.of(pointId));
+        if (lock) {
+            proto.setLockedPointList(List.of(pointId));
+        } else {
+            proto.setUnhidePointList(List.of(pointId));
+        }
     }
 
     public PacketScenePointUnlockNotify(int sceneId, Iterable<Integer> pointIds) {
@@ -28,16 +27,15 @@ public class PacketScenePointUnlockNotify extends BasePacket {
     }
 
     public PacketScenePointUnlockNotify(int sceneId, Iterable<Integer> pointIds, boolean lock) {
-        super(PacketOpcodes.ScenePointUnlockNotify);
-
-        ScenePointUnlockNotify.Builder p = ScenePointUnlockNotify.newBuilder()
-                .setSceneId(sceneId)
-                .addAllPointList(pointIds);
-        if(lock)
-            p.addAllLockedPointList(pointIds);
-        else
-            p.addAllUnhidePointList(pointIds);
-
-        this.setData(p);
+        super(new ScenePointUnlockNotify());
+        proto.setSceneId(sceneId);
+        List<Integer> pointIdsList = new ArrayList<>();
+        pointIds.forEach(pointIdsList::add);
+        proto.setPointList(pointIdsList);
+        if (lock) {
+            proto.setLockedPointList(pointIdsList);
+        } else {
+            proto.setUnhidePointList(pointIdsList);
+        }
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketSceneTransToPointRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketSceneTransToPointRsp.java
@@ -1,19 +1,14 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.packet.BaseTypedPacket;
 import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
-import emu.grasscutter.net.proto.SceneTransToPointRspOuterClass.SceneTransToPointRsp;
+import org.anime_game_servers.multi_proto.gi.messages.scene.SceneTransToPointRsp;
 
-public class PacketSceneTransToPointRsp extends BasePacket {
-
+public class PacketSceneTransToPointRsp extends BaseTypedPacket<SceneTransToPointRsp> {
     public PacketSceneTransToPointRsp(boolean result, int pointId, int sceneId) {
-        super(PacketOpcodes.SceneTransToPointRsp);
-
-        this.setData(SceneTransToPointRsp.newBuilder()
-            .setRetcode(result ? Retcode.RET_SUCC_VALUE : Retcode.RET_SVR_ERROR_VALUE) // Internal server error
-            .setPointId(pointId)
-            .setSceneId(sceneId)
-            .build());
+        super(new SceneTransToPointRsp());
+        proto.setPointId(pointId);
+        proto.setRetcode(result ? Retcode.RET_SUCC_VALUE : Retcode.RET_SVR_ERROR_VALUE);
+        proto.setSceneId(sceneId);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketServerCondMeetQuestListUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketServerCondMeetQuestListUpdateNotify.java
@@ -1,50 +1,20 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.GameQuest;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.ServerCondMeetQuestListUpdateNotifyOuterClass.ServerCondMeetQuestListUpdateNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.quest.ServerCondMeetQuestListUpdateNotify;
 
 import java.util.List;
-import java.util.Set;
 
-public class PacketServerCondMeetQuestListUpdateNotify extends BasePacket {
+public class PacketServerCondMeetQuestListUpdateNotify extends BaseTypedPacket<ServerCondMeetQuestListUpdateNotify> {
 
-    public PacketServerCondMeetQuestListUpdateNotify(Player player) {
-        super(PacketOpcodes.ServerCondMeetQuestListUpdateNotify);
-
-        ServerCondMeetQuestListUpdateNotify.Builder proto = ServerCondMeetQuestListUpdateNotify.newBuilder();
-
-        /*
-        player.getQuestManager().forEachQuest(quest -> {
-            if (quest.getState().getValue() <= 2) {
-                proto.addAddQuestIdList(quest.getQuestId());
-            }
-        });
-        */
-
-        this.setData(proto);
-    }
-
-    public PacketServerCondMeetQuestListUpdateNotify(List<GameQuest> quests) {
-        super(PacketOpcodes.ServerCondMeetQuestListUpdateNotify);
-
-        ServerCondMeetQuestListUpdateNotify.Builder proto = ServerCondMeetQuestListUpdateNotify.newBuilder();
-        for (GameQuest quest : quests) {
-            proto.addAddQuestIdList(quest.getSubQuestId());
-        }
-        proto.build();
-
-        this.setData(proto);
+    public PacketServerCondMeetQuestListUpdateNotify(List<GameQuest> addQuests, List<GameQuest> delQuests) {
+        super(new ServerCondMeetQuestListUpdateNotify());
+        proto.setAddQuestIdList(addQuests.stream().map(GameQuest::getSubQuestId).toList());
+        proto.setDelQuestIdList(delQuests.stream().map(GameQuest::getSubQuestId).toList());
     }
 
     public PacketServerCondMeetQuestListUpdateNotify() {
-        super(PacketOpcodes.ServerCondMeetQuestListUpdateNotify);
-
-        ServerCondMeetQuestListUpdateNotify.Builder proto = ServerCondMeetQuestListUpdateNotify.newBuilder();
-        proto.build();
-
-        this.setData(proto);
+        super(new ServerCondMeetQuestListUpdateNotify());
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockTransPointRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockTransPointRsp.java
@@ -1,19 +1,12 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
-import emu.grasscutter.net.proto.UnlockTransPointRspOuterClass.UnlockTransPointRsp;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import emu.grasscutter.net.proto.RetcodeOuterClass;
+import org.anime_game_servers.multi_proto.gi.messages.scene.UnlockTransPointRsp;
 
-public class PacketUnlockTransPointRsp extends BasePacket {
-    public PacketUnlockTransPointRsp(Retcode retcode) {
-        super(PacketOpcodes.UnlockTransPointRsp);
-
-        UnlockTransPointRsp proto = UnlockTransPointRsp.newBuilder()
-                .setRetcode(retcode.getNumber())
-                .build();
-
-        this.setData(proto);
+public class PacketUnlockTransPointRsp extends BaseTypedPacket<UnlockTransPointRsp> {
+    public PacketUnlockTransPointRsp(boolean unlocked) {
+        super(new UnlockTransPointRsp());
+        proto.setRetcode(unlocked ? RetcodeOuterClass.Retcode.RET_SUCC_VALUE : RetcodeOuterClass.Retcode.RET_FAIL_VALUE);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketWorktopOptionNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketWorktopOptionNotify.java
@@ -2,22 +2,18 @@ package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.gadget.GadgetWorktop;
-import emu.grasscutter.net.packet.BasePacket;
-import emu.grasscutter.net.packet.PacketOpcodes;
-import emu.grasscutter.net.proto.WorktopOptionNotifyOuterClass.WorktopOptionNotify;
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.gadget.WorktopOptionNotify;
 
-public class PacketWorktopOptionNotify extends BasePacket {
-	
+import java.util.ArrayList;
+
+public class PacketWorktopOptionNotify extends BaseTypedPacket<WorktopOptionNotify> {
+
 	public PacketWorktopOptionNotify(EntityGadget gadget) {
-		super(PacketOpcodes.WorktopOptionNotify);
-		
-		WorktopOptionNotify.Builder proto = WorktopOptionNotify.newBuilder()
-				.setGadgetEntityId(gadget.getId());
-		
+        super(new WorktopOptionNotify());
+        proto.setGadgetEntityId(gadget.getId());
 		if (gadget.getContent() instanceof GadgetWorktop worktop) {
-			proto.addAllOptionList(worktop.getWorktopOptions());
+            proto.setOptionIdList(new ArrayList<>(worktop.getWorktopOptions()));
 		}
-		
-		this.setData(proto);
 	}
 }


### PR DESCRIPTION
Notable other changes:
* Scene now uses multiproto VisionType
* PlayerCodex uses CodexTypes instead of ints
* Completely rewrote Friendship
* ToProto changed in GameItem, GameMainQuest, and GameQuest 
* PacketServerCondMeetQuestListUpdateNotify is unused. 
      Set it up a little better for future use with (add,del). 
* PacketGroupSuiteNotify is only saving one SuiteId? 
* HandlerQuestCreateEntityReq had a major rewrite, but was not checked.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [x] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.