### PR TITLE
Change way that finishProgressList is handled at login

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -4,6 +4,7 @@ import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Indexed;
 import dev.morphia.annotations.Transient;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.Loggers;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.common.quest.MainQuestData;
@@ -253,7 +254,7 @@ public class GameMainQuest {
         return null;
     }
 
-    public GameQuest getRewindTarget(){
+    public GameQuest getHighestActiveQuest() {
         var activeQuests = getChildQuests().values().stream()
             .filter(p -> (p.getState() == QuestState.QUEST_STATE_UNFINISHED || p.getState() == QuestState.QUEST_STATE_FINISHED)).toList();
         var highestActiveQuest = activeQuests.stream()
@@ -265,7 +266,7 @@ public class GameMainQuest {
             var firstUnstarted = getChildQuests().values().stream()
                 .filter(q -> q.getQuestData() != null && q.getState().getValue() != QuestState.QUEST_STATE_FINISHED.getValue())
                 .min(Comparator.comparingInt(a -> a.getQuestData().getOrder()));
-            if(firstUnstarted.isEmpty()){
+            if (firstUnstarted.isEmpty()) {
                 // all quests are probably finished, do don't rewind and maybe also set the mainquest to finished?
                 return null;
             }
@@ -273,14 +274,20 @@ public class GameMainQuest {
             //todo maybe try to accept quests if there is no active quest and no rewind target?
             //tryAcceptSubQuests(QuestTrigger.QUEST_COND_NONE, "", 0);
         }
+        return highestActiveQuest;
+    }
+
+    public GameQuest getRewindTarget(){
+        var highestActiveQuest = getHighestActiveQuest();
 
         var highestOrder = highestActiveQuest.getQuestData().getOrder();
         var rewindTarget = getChildQuests().values().stream()
             .filter(q -> q.getQuestData() != null)
             .filter(q -> q.getQuestData().isRewind() && q.getQuestData().getOrder() <= highestOrder)
             .max(Comparator.comparingInt(a -> a.getQuestData().getOrder()))
-            .orElse(highestActiveQuest);
+            .orElse(null);
 
+        Grasscutter.getLogger().trace("For quest {}, the rewindTarget is {}", this.getParentQuestId(), rewindTarget);
         return rewindTarget;
     }
 
@@ -353,10 +360,10 @@ public class GameMainQuest {
         return true;
     }
 
-    public void checkProgress(){
+    public void checkProgress(boolean shouldReset) {
         for (var quest : getChildQuests().values()){
             if(quest.getState() == QuestState.QUEST_STATE_UNFINISHED) {
-                questManager.checkQuestAlreadyFullfilled(quest);
+                questManager.checkQuestAlreadyFulfilled(quest, shouldReset);
             }
         }
     }

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -101,7 +101,7 @@ public class GameQuest {
         triggerStateEvents();
 
         getQuestData().getBeginExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(this, e, e.getParam()));
-        getOwner().getQuestManager().checkQuestAlreadyFullfilled(this);
+        getOwner().getQuestManager().checkQuestAlreadyFulfilled(this, true);
         getOwner().getDungeonEntryManager().checkQuestForDungeonEntryUpdate(this);
 
         Grasscutter.getLogger().debug("Quest {} is started", subQuestId);

--- a/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
@@ -101,7 +101,7 @@ public class QuestSystem extends BaseGameSystem {
     }
 
     public boolean initialCheckContent(GameQuest quest, int[] curProgress,
-                                          List<QuestContentCondition> conditions, LogicType logicType){
+                                       List<QuestContentCondition> conditions, LogicType logicType, boolean shouldReset) {
         val owner = quest.getOwner();
         var changed = false;
         int[] finished = new int[conditions.size()];
@@ -112,17 +112,18 @@ public class QuestSystem extends BaseGameSystem {
 
             val startingProgress = curProgress[i];
             int result = handler.initialCheck(quest, quest.getQuestData(), condition);
-            curProgress[i] = result;
+            if (shouldReset) curProgress[i] = result;
             if (startingProgress != result) {
                 changed = true;
             }
             finished[i] = handler.checkProgress(quest, condition, result) ? 1 : 0;
         }
-        if(changed) {
+        if (changed) {
             owner.getSession().send(new PacketQuestProgressUpdateNotify(quest));
         }
         return LogicType.calculate(logicType, finished);
     }
+
     public boolean checkAndUpdateContent(GameQuest quest, int[] curProgress,
                                           List<QuestContentCondition> conditions, LogicType logicType,
                                           QuestContent condType, String paramStr, int... params){
@@ -146,6 +147,7 @@ public class QuestSystem extends BaseGameSystem {
         }
         if(changed) {
             owner.getSession().send(new PacketQuestProgressUpdateNotify(quest));
+            quest.save();
         }
         return LogicType.calculate(logicType, finished);
     }


### PR DESCRIPTION
Quests that have isRewind=False cannot be rewind
Targets checkAndUpdateContent saves the quest if Content changed 
Don't modify finishProgressList if it's from a login



Fixes Prologue act 1 not finishing if you relogged while doing the dungeons.


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.