### PR TITLE
[BUGFIX] fix broken element changes at statues.

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/WorldAreaData.java
+++ b/src/main/java/emu/grasscutter/data/excels/WorldAreaData.java
@@ -1,32 +1,25 @@
 package emu.grasscutter.data.excels;
 
+import com.google.gson.annotations.SerializedName;
 import emu.grasscutter.data.GameResource;
 import emu.grasscutter.data.ResourceType;
 import emu.grasscutter.game.props.ElementType;
+import lombok.Getter;
 
 @ResourceType(name = "WorldAreaConfigData.json")
 public class WorldAreaData extends GameResource {
-	private int id;
-	private int areaID1;
-	private int areaID2;
-	private int sceneID;
-	private ElementType elementType;
+    private int ID;
+    @Getter @SerializedName("AreaID1")
+    private int areaID1;
+    @Getter @SerializedName("AreaID2")
+    private int areaID2;
+    @Getter @SerializedName("SceneID")
+    private int sceneID;
+    @Getter
+    private ElementType elementType;
 
-	@Override
-	public int getId() {
-		return (this.areaID2 << 16) + this.areaID1;
-	}
-
-	public int getSceneID() {
-		return this.sceneID;
-	}
-
-	public ElementType getElementType() {
-		return this.elementType;
-	}
-
-	@Override
-	public void onLoad() {
-
-	}
+    @Override
+    public int getId() {
+        return (this.areaID2 << 16) + this.areaID1;
+    }
 }


### PR DESCRIPTION
## Description

Going to a Statue of the seven and choosing "Resonate with {X}" wouldn't result in any changes.
worldAreaDataMap was empty!
My resources have keys that start with capital letters, where Grasscutter expects lower case.

Compare with https://github.com/Grasscutters/Grasscutter/blob/development/src/main/java/emu/grasscutter/data/excels/world/WorldAreaData.java

Doing this change fixed statues in Liyue and Inazuma. Sumeru's statues don't give you the choice to interact with them.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.