### PR TITLE
Add EVENT_GATHER to GadgetGatherObject

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
@@ -13,6 +13,8 @@ import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.server.packet.send.PacketGadgetInteractRsp;
 import emu.grasscutter.utils.Utils;
 import lombok.val;
+import org.anime_game_servers.gi_lua.models.ScriptArgs;
+import org.anime_game_servers.gi_lua.models.constants.EventType;
 import org.anime_game_servers.multi_proto.gi.messages.gadget.GadgetInteractReq;
 import org.anime_game_servers.multi_proto.gi.messages.gadget.InteractType;
 import org.anime_game_servers.multi_proto.gi.messages.scene.entity.GatherGadgetInfo;
@@ -57,6 +59,10 @@ public class GadgetGatherObject extends GadgetContent {
 
         GameItem item = new GameItem(itemData, 1);
         player.getInventory().addItem(item, ActionReason.Gather);
+
+        var ScriptArgs = new ScriptArgs(getGadget().getGroupId(), EventType.EVENT_GATHER, getGadget().getConfigId());
+        ScriptArgs.setEventSource(getGadget().getConfigId());
+        getGadget().getScene().getScriptManager().callEvent(ScriptArgs);
 
         getGadget().getScene().broadcastPacket(new PacketGadgetInteractRsp(getGadget(), InteractType.INTERACT_GATHER));
 


### PR DESCRIPTION
## Description
See https://github.com/Grasscutters/Grasscutter/pull/2272 and https://github.com/Grasscutters/Grasscutter/pull/2218
This time, I had trouble with GATHER_16001 in group 166001016. So I'm borrowing some code from those PRs.


## Issues fixed by this PR

Can now collect the Adjuvant in the Chasm

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.