### PR TITLE
Use getGroupIdOrCurrentId when possible

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/ScriptLibHandler.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLibHandler.java
@@ -239,7 +239,7 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
 
         val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val scriptManager = context.getSceneScriptManager();
-        SceneGroup group = getGroupOrCurrent(context, actualGroupId);
+        SceneGroup group = getGroupOrCurrent(context, groupId);
         SceneGroupInstance groupInstance = scriptManager.getGroupInstanceById(actualGroupId);
         if (group == null || groupInstance == null) {
             return 1;
@@ -1046,7 +1046,7 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call check RefreshBlossomGroup with {}", printTable(configTable));
 
         val actualGroupId = getGroupIdOrCurrentId(context, configTable.optInt("group_id", 0));
-        val group = getGroupOrCurrent(context, actualGroupId);
+        val group = getGroupOrCurrent(context, configTable.optInt("group_id", 0));
         if (group == null) return 1;
 
         val groupInstance = context.getSceneScriptManager().getGroupInstanceById(actualGroupId);

--- a/src/main/java/emu/grasscutter/scripts/ScriptLibHandler.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLibHandler.java
@@ -100,8 +100,10 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
 
     @Override
     public int SetGadgetEnableInteract(GroupEventLuaContext context, int groupId, int configId, boolean enable) {
-        val manager = context.getSceneScriptManager();
-        val entity = manager.getScene().getEntityByConfigId(configId, groupId);
+
+        val scene = context.getSceneScriptManager().getScene();
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val entity = scene.getEntityByConfigId(configId, actualGroupId);
         if(entity == null) return -1;
 
         if((entity instanceof EntityGadget gadget)){
@@ -117,7 +119,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call SetWorktopOptionsByGroupId with {},{},{}",
             groupId,configId,printTable(options));
 
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, groupId);
+        val scene = context.getSceneScriptManager().getScene();
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val entity = scene.getEntityByConfigId(configId, actualGroupId);
 
         if (!(entity instanceof EntityGadget gadget)) {
             return 1;
@@ -166,7 +170,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int DelWorktopOptionByGroupId(GroupEventLuaContext context, int groupId, int configId, int option) {
         logger.debug("[LUA] Call DelWorktopOptionByGroupId with {},{},{}",groupId,configId,option);
 
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, groupId);
+        val scene = context.getSceneScriptManager().getScene();
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val entity = scene.getEntityByConfigId(configId, actualGroupId);
 
         if (!(entity instanceof EntityGadget gadget)) {
             return 1;
@@ -215,7 +221,7 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call AutoMonsterTide with {},{},{},{},{},{}",
             challengeIndex,groupId,ordersConfigId,tideCount,sceneLimit,param6);
 
-        SceneGroup group = context.getSceneScriptManager().getGroupById(groupId);
+        val group = getGroupOrCurrent(context, groupId);
 
         if (group == null || group.getMonsters() == null) {
             return 1;
@@ -230,9 +236,11 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int GoToGroupSuite(GroupEventLuaContext context, int groupId, int suite) {
         logger.debug("[LUA] Call GoToGroupSuite with {},{}",
             groupId,suite);
+
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val scriptManager = context.getSceneScriptManager();
-        SceneGroup group = scriptManager.getGroupById(groupId);
-        SceneGroupInstance groupInstance = scriptManager.getGroupInstanceById(groupId);
+        SceneGroup group = getGroupOrCurrent(context, actualGroupId);
+        SceneGroupInstance groupInstance = scriptManager.getGroupInstanceById(actualGroupId);
         if (group == null || groupInstance == null) {
             return 1;
         }
@@ -261,20 +269,20 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call AddExtraGroupSuite with {},{}",
             groupId,suite);
         val scriptManager = context.getSceneScriptManager();
-
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         SceneGroup group = getGroupOrCurrent(context, groupId);
         if (group == null) {
             return 1;
         }
 
-        SceneGroupInstance groupInstance = scriptManager.getGroupInstanceById(group.getGroupInfo().getId());
+        SceneGroupInstance groupInstance = scriptManager.getGroupInstanceById(actualGroupId);
         if (groupInstance == null) {
             return 1;
         }
 
         var suiteData = group.getSuiteByIndex(suite);
         if(suiteData == null){
-            logger.warn("trying to get suite that doesn't exist: {} {}", groupId, suite);
+            logger.warn("trying to get suite that doesn't exist: {} {}", actualGroupId, suite);
             return 1;
         }
         scriptManager.addGroupSuite(groupInstance, suiteData);
@@ -340,9 +348,10 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call ActiveChallenge with {},{},{},{},{},{}",
             challengeIndex, challengeId, timeLimitOrGroupId,groupId,objectiveKills,param5);
 
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val challenge = ChallengeFactory.getChallenge(
             new ChallengeInfo(challengeIndex, challengeId, 0),
-            List.of(timeLimitOrGroupId, groupId, objectiveKills, param5),
+            List.of(timeLimitOrGroupId, actualGroupId, objectiveKills, param5),
             new ChallengeScoreInfo(0, 0),
             context.getSceneScriptManager().getScene(),
             context.getCurrentGroup()
@@ -415,8 +424,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int GetGroupMonsterCountByGroupId(GroupEventLuaContext context, int groupId) {
         logger.debug("[LUA] Call GetGroupMonsterCountByGroupId with {}",
             groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         return (int) context.getSceneScriptManager().getScene().getEntities().values().stream()
-            .filter(e -> e instanceof EntityMonster && e.getGroupId() == groupId)
+            .filter(e -> e instanceof EntityMonster && e.getGroupId() == actualGroupId)
             .count();
     }
 
@@ -465,7 +475,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int GetGroupVariableValue(GroupEventLuaContext context, String var) {
         logger.debug("[LUA] Call GetGroupVariableValue with {}",
             var);
-        return getGroupVariableValue(context.getSceneScriptManager(), context.getCurrentGroup().getGroupInfo().getId(), var);
+
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        return getGroupVariableValue(context.getSceneScriptManager(), groupId, var);
     }
 
     @Override
@@ -473,7 +485,8 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call GetGroupVariableValueByGroup with {},{}",
             name,groupId);
 
-        return getGroupVariableValue(context.getSceneScriptManager(), groupId, name);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        return getGroupVariableValue(context.getSceneScriptManager(), actualGroupId, name);
     }
 
     @Override
@@ -490,7 +503,8 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call SetGroupVariableValueByGroup with {},{},{}",
             key,value,groupId);
 
-        return modifyGroupVariableValue(context.getSceneScriptManager(), groupId, key, value, true);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        return modifyGroupVariableValue(context.getSceneScriptManager(), actualGroupId, key, value, true);
     }
 
     @Override
@@ -507,7 +521,8 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call ChangeGroupVariableValueByGroup with {},{}",
             name,groupId);
 
-        return modifyGroupVariableValue(context.getSceneScriptManager(), groupId, name, value, false);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        return modifyGroupVariableValue(context.getSceneScriptManager(), actualGroupId, name, value, false);
     }
 
     @Override
@@ -515,7 +530,7 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call RefreshGroup with {}",
             printTable(table));
         // Kill and Respawn?
-        val groupId = table.getInt("group_id");
+        val groupId = getGroupIdOrCurrentId(context, table.getInt("group_id"));
         val suite = table.getInt("suite");
 
         SceneGroupInstance groupInstance = context.getSceneScriptManager().getGroupInstanceById(groupId);
@@ -577,8 +592,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         // TODO implement scene50008_group250008057.lua uses incomplete group numbers
 
         val scene = context.getSceneScriptManager().getScene();
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         // -> MonsterForceAlertNotify
-        var entity = scene.getEntityByConfigId(configId, groupId);
+        var entity = scene.getEntityByConfigId(configId, actualGroupId);
         if(entity != null && entity instanceof EntityMonster monster) {
             scene.broadcastPacket(new PacketMonsterForceAlertNotify(monster.getId()));
         }
@@ -708,10 +724,10 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int CheckRemainGadgetCountByGroupId(GroupEventLuaContext context, LuaTable table) {
         logger.debug("[LUA] Call CheckRemainGadgetCountByGroupId with {}",
             printTable(table));
-        var groupId = table.getInt("group_id");
+        val actualGroupId = getGroupIdOrCurrentId(context, table.getInt("group_id"));
 
         var count = context.getSceneScriptManager().getScene().getEntities().values().stream()
-            .filter(g -> g instanceof EntityGadget entityGadget && entityGadget.getGroupId() == groupId)
+            .filter(g -> g instanceof EntityGadget entityGadget && entityGadget.getGroupId() == actualGroupId)
             .count();
         return (int)count;
     }
@@ -776,7 +792,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int RemoveEntityByConfigId(GroupEventLuaContext context, int groupId, EntityType entityType, int configId) {
         logger.debug("[LUA] Call RemoveEntityByConfigId");
 
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val scene = context.getSceneScriptManager().getScene();
+        val entity = scene.getEntityByConfigId(configId, actualGroupId);
 
         if(entity == null || !entity.getEntityType().name().toUpperCase().equals(entityType.name())){
             return 1;
@@ -788,19 +806,22 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     }
 
     @Override
-    public int CreateGroupTimerEvent(GroupEventLuaContext context, int groupID, String source, double time) {
-        return context.getSceneScriptManager().createGroupTimerEvent(groupID, source, time);
+    public int CreateGroupTimerEvent(GroupEventLuaContext context, int groupId, String source, double time) {
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        return context.getSceneScriptManager().createGroupTimerEvent(actualGroupId, source, time);
     }
 
     @Override
-    public int CancelGroupTimerEvent(GroupEventLuaContext context, int groupID, String source) {
-        return context.getSceneScriptManager().cancelGroupTimerEvent(groupID, source);
+    public int CancelGroupTimerEvent(GroupEventLuaContext context, int groupId, String source) {
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        return context.getSceneScriptManager().cancelGroupTimerEvent(actualGroupId, source);
     }
 
     @Override
     public int GetGroupSuite(GroupEventLuaContext context, int groupId) {
         //logger.warn("[LUA] Call GetGroupSuite with {}", groupID);
-        var instance = context.getSceneScriptManager().getGroupInstanceById(groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        var instance = context.getSceneScriptManager().getGroupInstanceById(actualGroupId);
         if(instance != null) return instance.getActiveSuiteId();
         return 0;
     }
@@ -809,7 +830,8 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int SetGroupReplaceable(GroupEventLuaContext context, int groupId, boolean value) {
         logger.warn("[LUA] Call SetGroupReplaceable with {} {}", groupId, value);
 
-        var group = context.getSceneScriptManager().getCachedGroupInstanceById(groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        var group = context.getSceneScriptManager().getCachedGroupInstanceById(actualGroupId);
         if(group != null && group.isReplaceable() != null) {
             group.setReplaceable(value);
             return 0;
@@ -974,18 +996,19 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int CreateBlossomChestByGroupId(GroupEventLuaContext context, int groupId, int chestConfigId) {
         logger.debug("[LUA] Call check CreateBlossomChestByGroupId with {} {}", groupId, chestConfigId);
 
-        val currentGroup = context.getSceneScriptManager().getGroupById(groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val currentGroup = getGroupOrCurrent(context, groupId);
         if (currentGroup == null) return 1;
 
         val gadget = currentGroup.getGadgets().get(chestConfigId);
-        val chestGadget = context.getSceneScriptManager().createGadget(groupId, currentGroup.getGroupInfo().getBlockId(), gadget);
+        val chestGadget = context.getSceneScriptManager().createGadget(actualGroupId, currentGroup.getGroupInfo().getBlockId(), gadget);
         if (chestGadget == null) return 1;
 
         val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
-        val blossomSchedule = blossomManager.getBlossomSchedule().get(groupId);
+        val blossomSchedule = blossomManager.getBlossomSchedule().get(actualGroupId);
         if (blossomSchedule == null) return 1;
 
-        blossomManager.getSpawnedChest().put(chestGadget.getConfigId(), groupId);
+        blossomManager.getSpawnedChest().put(chestGadget.getConfigId(), actualGroupId);
         context.getSceneScriptManager().addEntity(chestGadget);
         context.getSceneScriptManager().getScene().broadcastPacket(
             new PacketBlossomChestCreateNotify(blossomSchedule.getRefreshId(), blossomSchedule.getCircleCampId()));
@@ -997,9 +1020,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call check GetBlossomScheduleStateByGroupId with {}", groupId);
         if (context.getCurrentGroup() == null) return -1;
 
-        val realGroupId = getGroupIdOrCurrentId(context, groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
-        return Optional.ofNullable(blossomManager.getBlossomSchedule().get(realGroupId))
+        return Optional.ofNullable(blossomManager.getBlossomSchedule().get(actualGroupId))
             .map(BlossomSchedule::getState).orElse(-1);
     }
 
@@ -1008,11 +1031,11 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
         logger.debug("[LUA] Call check SetBlossomScheduleStateByGroupId with {} {}", groupId, state);
 
         val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
-        val realGroupId = getGroupIdOrCurrentId(context, groupId);
-        val result = blossomManager.setBlossomState(realGroupId, state);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val result = blossomManager.setBlossomState(actualGroupId, state);
         if (result && state == 1) { // there should only be one gadget of this blossom at this point, which is the operator
             context.getSceneScriptManager().getScene().getEntities().values().stream()
-                .filter(entity -> entity.getGroupId() == realGroupId).filter(EntityGadget.class::isInstance)
+                .filter(entity -> entity.getGroupId() == actualGroupId).filter(EntityGadget.class::isInstance)
                 .map(EntityGadget.class::cast).findFirst().ifPresent(gadget -> gadget.updateState(ScriptGadgetState.GearAction2));
         }
         return result ? 0 : 1;
@@ -1022,26 +1045,24 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int RefreshBlossomGroup(GroupEventLuaContext context, LuaTable configTable) {
         logger.debug("[LUA] Call check RefreshBlossomGroup with {}", printTable(configTable));
 
-        int groupId = configTable.optInt("group_id", context.getCurrentGroup().getGroupInfo().getId());
-        val group = getGroupOrCurrent(context, groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, configTable.optInt("group_id", 0));
+        val group = getGroupOrCurrent(context, actualGroupId);
         if (group == null) return 1;
 
-        groupId = group.getGroupInfo().getId();
-
-        val groupInstance = context.getSceneScriptManager().getGroupInstanceById(groupId);
+        val groupInstance = context.getSceneScriptManager().getGroupInstanceById(actualGroupId);
         int suiteIndex = configTable.getInt("suite");
         val suite = group.getSuiteByIndex(suiteIndex);
         if (suite == null || groupInstance == null) return 1;
 
         context.getSceneScriptManager().refreshGroup(groupInstance, suiteIndex, configTable.getBoolean("exclude_prev"));
         val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
-        val schedule = blossomManager.getBlossomSchedule().get(groupId);
+        val schedule = blossomManager.getBlossomSchedule().get(actualGroupId);
         if (schedule == null) return 0;
 
         val spawnedChest = blossomManager.getSpawnedChest().values().stream()
             .filter(gid -> gid == schedule.getGroupId()).findFirst().orElse(null);
         context.getSceneScriptManager().callEvent(new ScriptArgs(
-            groupId, spawnedChest == null ? EventType.EVENT_GROUP_REFRESH : EventType.EVENT_BLOSSOM_PROGRESS_FINISH));
+            actualGroupId, spawnedChest == null ? EventType.EVENT_GROUP_REFRESH : EventType.EVENT_BLOSSOM_PROGRESS_FINISH));
         return 0;
     }
 
@@ -1053,17 +1074,19 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     @Override
     public int AddBlossomScheduleProgressByGroupId(GroupEventLuaContext context, int groupId) {
         logger.debug("[LUA] Call check AddBlossomScheduleProgressByGroupId with {}", groupId);
+
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
-        return blossomManager.addBlossomProgress(groupId) ? 0 : 1;
+        return blossomManager.addBlossomProgress(actualGroupId) ? 0 : 1;
     }
 
     @Override
     public int GetBlossomRefreshTypeByGroupId(GroupEventLuaContext context, int groupId) {
         logger.debug("[LUA] Call check GetBlossomRefreshTypeByGroupId with {}", groupId);
 
-        val realGroupId = getGroupIdOrCurrentId(context, groupId);
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val blossomManager = context.getSceneScriptManager().getScene().getWorld().getHost().getBlossomManager();
-        return Optional.ofNullable(blossomManager.getBlossomSchedule().get(realGroupId))
+        return Optional.ofNullable(blossomManager.getBlossomSchedule().get(actualGroupId))
             .map(BlossomSchedule::getRefreshType).map(BlossomRefreshType::getValue).orElse(2);
     }
 
@@ -1435,7 +1458,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int SetPlatformPointArray(GroupEventLuaContext context, int entityConfigId, int pointArrayId, LuaTable var3, LuaTable var4) {
         logger.warn("[LUA] Call unimplemented SetPlatformPointArray with {} {} {} {}", entityConfigId, pointArrayId, printTable(var3), printTable(var4));
 
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(entityConfigId, context.getCurrentGroup().getGroupInfo().getId());
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        val scene = context.getSceneScriptManager().getScene();
+        val entity = scene.getEntityByConfigId(entityConfigId, groupId);
         if(entity == null){
             return 1;
         }
@@ -1466,8 +1491,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int SetPlatformRouteId(GroupEventLuaContext context, int entityConfigId, int routeId) {
         logger.info("[LUA] Call SetPlatformRouteId {} {}", entityConfigId, routeId);
 
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
         val scene = context.getSceneScriptManager().getScene();
-        val entity = scene.getEntityByConfigId(entityConfigId, context.getCurrentGroup().getGroupInfo().getId());
+        val entity = scene.getEntityByConfigId(entityConfigId, groupId);
         if(entity == null){
             return 1;
         }
@@ -1498,8 +1524,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int StartPlatform(GroupEventLuaContext context, int configId) {
         logger.info("[LUA] Call StartPlatform {} ", configId);
 
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, context.getCurrentGroup().getGroupInfo().getId());
-
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        val scene = context.getSceneScriptManager().getScene();
+        val entity = scene.getEntityByConfigId(configId, groupId);
         if(!(entity instanceof EntityGadget entityGadget)) {
             return 1;
         }
@@ -1510,7 +1537,10 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     @Override
     public int StopPlatform(GroupEventLuaContext context, int configId) {
         logger.info("[LUA] Call StopPlatform {} ", configId);
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, context.getCurrentGroup().getGroupInfo().getId());
+
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        val scene = context.getSceneScriptManager().getScene();
+        val entity = scene.getEntityByConfigId(configId, groupId);
         if(!(entity instanceof EntityGadget entityGadget)) {
             return 1;
         }
@@ -1590,7 +1620,7 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int KillGroupEntityByCfgIds(GroupEventLuaContext context, int groupId, int[] monsters, int[] gadgets) {
         val sceneManager = context.getSceneScriptManager();
 
-        val group = sceneManager.getGroupById(groupId);
+        val group = getGroupOrCurrent(context, groupId);
         if (group == null) {
             return 10;
         }
@@ -1618,7 +1648,7 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int KillGroupEntityByPolicy(GroupEventLuaContext context, int groupId, GroupKillPolicy policy) {
         val sceneManager = context.getSceneScriptManager();
 
-        val group = sceneManager.getGroupById(groupId);
+        val group = getGroupOrCurrent(context, groupId);
         if (group == null) {
             return 10;
         }
@@ -1674,7 +1704,9 @@ public class ScriptLibHandler extends BaseHandler implements org.anime_game_serv
     public int GetEntityIdByConfigId(GroupEventLuaContext context, int configId) {
         logger.warn("[LUA] Call GetEntityIdByConfigId with {}", configId);
         //TODO check
-        var entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, context.getCurrentGroup().getGroupInfo().getId());
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        val scene = context.getSceneScriptManager().getScene();
+        var entity = scene.getEntityByConfigId(configId, groupId);
         return entity != null ? entity.getId() : 0;
     }
 

--- a/src/main/java/emu/grasscutter/scripts/scriptlib_handlers/entities/GroupGadgetHandler.java
+++ b/src/main/java/emu/grasscutter/scripts/scriptlib_handlers/entities/GroupGadgetHandler.java
@@ -8,7 +8,6 @@ import emu.grasscutter.scripts.lua_engine.GroupEventLuaContext;
 import emu.grasscutter.scripts.scriptlib_handlers.BaseHandler;
 import lombok.Getter;
 import lombok.val;
-import org.anime_game_servers.lua.engine.LuaTable;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
@@ -24,7 +23,10 @@ public class GroupGadgetHandler extends BaseHandler implements org.anime_game_se
     public int ChangeGroupGadget(GroupEventLuaContext context, int configId, int state) {
         logger.debug("[LUA] Call ChangeGroupGadget with {} {}", configId, state);
 
-        var entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, context.getCurrentGroup().getGroupInfo().getId());
+        val scene = context.getSceneScriptManager().getScene();
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        val entity = scene.getEntityByConfigId(configId, groupId);
+
         if(entity == null){
             return 1;
         }
@@ -58,8 +60,12 @@ public class GroupGadgetHandler extends BaseHandler implements org.anime_game_se
     }
 
     @Override
-    public int GetGadgetHpPercent(@NotNull GroupEventLuaContext groupEventLuaContext, int groupId, int configId) {
-        val entity = groupEventLuaContext.getSceneScriptManager().getScene().getEntityByConfigId(configId, groupId);
+    public int GetGadgetHpPercent(@NotNull GroupEventLuaContext context, int groupId, int configId) {
+
+        val scene = context.getSceneScriptManager().getScene();
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val entity = scene.getEntityByConfigId(configId, actualGroupId);
+
         if(entity == null){
             return INVALID_PARAMETER.getValue();
         }
@@ -91,6 +97,7 @@ public class GroupGadgetHandler extends BaseHandler implements org.anime_game_se
         val scene = context.getSceneScriptManager().getScene();
         val actualGroupId = getGroupIdOrCurrentId(context, groupId);
         val gadget = scene.getEntityByConfigId(configId, actualGroupId);
+
         if(!(gadget instanceof EntityGadget)){
             return -1;
         }
@@ -101,7 +108,10 @@ public class GroupGadgetHandler extends BaseHandler implements org.anime_game_se
     public int SetGadgetStateByConfigId(GroupEventLuaContext context, int configId, int gadgetState) {
         logger.debug("[LUA] Call SetGadgetStateByConfigId with {},{}",
             configId,gadgetState);
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, context.getCurrentGroup().getGroupInfo().getId());
+
+        val scene = context.getSceneScriptManager().getScene();
+        val groupId = context.getCurrentGroup().getGroupInfo().getId();
+        val entity = scene.getEntityByConfigId(configId, groupId);
 
         if (!(entity instanceof EntityGadget)) {
             return 1;
@@ -116,7 +126,10 @@ public class GroupGadgetHandler extends BaseHandler implements org.anime_game_se
         logger.debug("[LUA] Call SetGroupGadgetStateByConfigId with {},{},{}",
             groupId,configId,gadgetState);
 
-        val entity = context.getSceneScriptManager().getScene().getEntityByConfigId(configId, groupId);
+        val scene = context.getSceneScriptManager().getScene();
+        val actualGroupId = getGroupIdOrCurrentId(context, groupId);
+        val entity = scene.getEntityByConfigId(configId, actualGroupId);
+
         if(!(entity instanceof EntityGadget)){
             return -1;
         }


### PR DESCRIPTION
## Description
Sometimes, groupId is 0. That means you use the current group. We have a function to make that easy to do!

Fixes group 166001305

before:
![image](https://github.com/user-attachments/assets/e2bcb00b-1291-4671-962b-86898f465591)
![image](https://github.com/user-attachments/assets/3c892e81-0e2d-45cf-bfec-f2cb3e7f9c5b)

after:
![image](https://github.com/user-attachments/assets/0624da73-f266-4143-9fbc-539783d0222c)



<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.