### PR TITLE
Framework for EntityTag

### DIFF
--- a/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
+++ b/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
@@ -118,6 +118,7 @@ public class AbilityModifier implements Serializable {
         public boolean lethal = true;
 
         public boolean muteHealEffect = false;
+        public boolean isAdd = false;
 
         public boolean byServer;
         public boolean lifeByOwnerIsAlive;

--- a/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
+++ b/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
@@ -144,6 +144,7 @@ public class AbilityModifier implements Serializable {
         public DynamicFloat valueRangeMin;
         public DynamicFloat valueRangeMax;
         public String overrideMapKey;
+        public String tag;
 
         public int paramNum;
         public DynamicFloat param1 = DynamicFloat.ZERO;

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionChangeTag.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionChangeTag.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.game.ability.actions;
+
+import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
+import emu.grasscutter.game.ability.Ability;
+import emu.grasscutter.game.entity.GameEntity;
+import emu.grasscutter.server.packet.send.PacketEntityTagChangeNotify;
+
+@AbilityAction(AbilityModifierAction.Type.ChangeTag)
+public class ActionChangeTag extends AbilityActionHandler {
+    @Override
+    public boolean execute(Ability ability, AbilityModifierAction action, byte[] abilityData, GameEntity target) {
+        ability.getPlayerOwner().sendPacket(new PacketEntityTagChangeNotify(target.getId(), true, action.tag));
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionChangeTag.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionChangeTag.java
@@ -7,9 +7,10 @@ import emu.grasscutter.server.packet.send.PacketEntityTagChangeNotify;
 
 @AbilityAction(AbilityModifierAction.Type.ChangeTag)
 public class ActionChangeTag extends AbilityActionHandler {
+
     @Override
     public boolean execute(Ability ability, AbilityModifierAction action, byte[] abilityData, GameEntity target) {
-        ability.getPlayerOwner().sendPacket(new PacketEntityTagChangeNotify(target.getId(), true, action.tag));
+        target.changeTag(action.tag, action.isAdd);
         return true;
     }
 }

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionChangeTag.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionChangeTag.java
@@ -3,7 +3,6 @@ package emu.grasscutter.game.ability.actions;
 import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
 import emu.grasscutter.game.ability.Ability;
 import emu.grasscutter.game.entity.GameEntity;
-import emu.grasscutter.server.packet.send.PacketEntityTagChangeNotify;
 
 @AbilityAction(AbilityModifierAction.Type.ChangeTag)
 public class ActionChangeTag extends AbilityActionHandler {

--- a/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
@@ -247,6 +247,7 @@ public class EntityAvatar extends GameEntity {
         entityInfo.setLastMoveSceneTimeMs(this.getLastMoveSceneTimeMs());
         entityInfo.setLastMoveReliableSeq(this.getLastMoveReliableSeq());
         entityInfo.setLifeState(this.getLifeState().getValue());
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
         if (this.getScene() != null) {
             entityInfo.setMotionInfo(this.getMotionInfo());

--- a/src/main/java/emu/grasscutter/game/entity/EntityClientGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityClientGadget.java
@@ -64,6 +64,7 @@ public class EntityClientGadget extends EntityBaseGadget implements ConfigAbilit
         entityInfo.setEntityClientData(new EntityClientData());
         entityInfo.setEntityAuthorityInfo(authority);
         entityInfo.setLifeState(1);
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
         val pair = new PropPair(PlayerProperty.PROP_LEVEL.getId(), ProtoHelper.newPropValue(PlayerProperty.PROP_LEVEL, getLevel()));
         entityInfo.setPropList(List.of(pair));

--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -265,6 +265,7 @@ public class EntityGadget extends EntityBaseGadget implements ConfigAbilityDataA
         entityInfo.setEntityClientData(new EntityClientData());
         entityInfo.setEntityAuthorityInfo(authority);
         entityInfo.setLifeState(1);
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
         val pair = new PropPair(PlayerProperty.PROP_LEVEL.getId(), ProtoHelper.newPropValue(PlayerProperty.PROP_LEVEL, getLevel()));
         entityInfo.setPropList(List.of(pair));

--- a/src/main/java/emu/grasscutter/game/entity/EntityItem.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityItem.java
@@ -56,6 +56,7 @@ public class EntityItem extends EntityBaseGadget {
         entityInfo.setEntityClientData(new EntityClientData());
         entityInfo.setEntityAuthorityInfo(authority);
         entityInfo.setLifeState(1);
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
         val pair = new PropPair(PlayerProperty.PROP_LEVEL.getId(), ProtoHelper.newPropValue(PlayerProperty.PROP_LEVEL, 1));
         entityInfo.setPropList(List.of(pair));

--- a/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
@@ -327,6 +327,7 @@ public class EntityMonster extends GameEntity<CreateMonsterEntityConfig> impleme
         entityInfo.setEntityClientData(new EntityClientData());
         entityInfo.setEntityAuthorityInfo(authority);
         entityInfo.setLifeState(this.getLifeState().getValue());
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
 
         this.addAllFightPropsToEntityInfo(entityInfo);

--- a/src/main/java/emu/grasscutter/game/entity/EntityNPC.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityNPC.java
@@ -61,6 +61,7 @@ public class EntityNPC extends GameEntity<CreateNpcEntityConfig> {
         entityInfo.setEntityClientData(new EntityClientData());
         entityInfo.setEntityAuthorityInfo(authority);
         entityInfo.setLifeState(1);
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
 
         val npc = new SceneNpcInfo(npcId);

--- a/src/main/java/emu/grasscutter/game/entity/EntityVehicle.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityVehicle.java
@@ -85,6 +85,7 @@ public class EntityVehicle extends EntityBaseGadget {
         entityInfo.setEntity(new SceneEntityInfo.Entity.Gadget(gadgetInfo));
         entityInfo.setEntityAuthorityInfo(authority);
         entityInfo.setLifeState(1);
+        entityInfo.setTagList(getEntityTags().stream().toList());
 
 
         this.addAllFightPropsToEntityInfo(entityInfo);

--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -14,6 +14,7 @@ import emu.grasscutter.scripts.data.controller.EntityController;
 import emu.grasscutter.server.event.entity.EntityDamageEvent;
 import emu.grasscutter.server.event.entity.EntityDeathEvent;
 import emu.grasscutter.server.packet.send.PacketEntityFightPropUpdateNotify;
+import emu.grasscutter.server.packet.send.PacketEntityTagChangeNotify;
 import emu.grasscutter.utils.Position;
 import it.unimi.dsi.fastutil.ints.Int2FloatMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -54,6 +55,7 @@ public abstract class GameEntity<T extends CreateEntityConfig<?>> {
     @Getter private List<Ability> instancedAbilities = new ArrayList<>();
     @Getter private Int2ObjectMap<AbilityModifierController> instancedModifiers = new Int2ObjectOpenHashMap<>();
     @Getter private Map<String, Float> globalAbilityValues = new HashMap<>();
+    @Getter private Set<String> entityTags = new HashSet<>();
 
     protected GameEntity(Scene scene) {
         this.scene = scene;
@@ -216,6 +218,18 @@ public abstract class GameEntity<T extends CreateEntityConfig<?>> {
 
     public void callAbilityBeHurt(EntityDamageEvent event) {
         //instancedAbilities.forEach(ability -> ability.onBeingHit(event));
+    }
+
+    public void changeTag(String tag, boolean isAdd) {
+        var wasChanges = false;
+        if (isAdd) {
+            wasChanges = this.entityTags.add(tag);
+        } else {
+            wasChanges = this.entityTags.remove(tag);
+        }
+        if(wasChanges){
+            scene.broadcastPacket(new PacketEntityTagChangeNotify(getId(), isAdd, tag));
+        }
     }
 
     /**

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEntityTagChangeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEntityTagChangeNotify.java
@@ -1,0 +1,13 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BaseTypedPacket;
+import org.anime_game_servers.multi_proto.gi.messages.scene.entity.EntityTagChangeNotify;
+
+public class PacketEntityTagChangeNotify extends BaseTypedPacket<EntityTagChangeNotify> {
+    public PacketEntityTagChangeNotify(int entityId, boolean isAdd, String tag) {
+        super(new EntityTagChangeNotify());
+        proto.setEntityId(entityId);
+        proto.setAdd(isAdd);
+        proto.setTag(tag);
+    }
+}


### PR DESCRIPTION
## Description
Unsure what entity tags do.
This solves no known bugs.
ChangeTag happens when picking up an Electrogranum, but this change did not change broken behavior. 
As discussed before, I'm committing this instead of shelving it.

It might be a good idea to store EntityTag information on the entity in the server too?

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.