### PR TITLE
Make region entering/leaving symmetrical

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
@@ -20,6 +20,7 @@ public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
     private boolean hasNewEntities;
     private boolean entityLeave;
     private final Set<GameEntity> entities; // Ids of entities inside this region
+    private final Set<GameEntity> notContainEntities; // Ids of entities outside this region
     private final Set<GameEntity> newEntities; // Ids that entered this region since the last check
     private final Set<GameEntity> leftEntities; // Ids that left this region since the last check
 
@@ -28,17 +29,20 @@ public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
         this.id = getScene().getWorld().getNextEntityId(EntityIdType.REGION);
         this.position = createConfig.getPos();
         this.entities = ConcurrentHashMap.newKeySet();
+        this.notContainEntities = ConcurrentHashMap.newKeySet();
         this.newEntities = ConcurrentHashMap.newKeySet();
         this.leftEntities = ConcurrentHashMap.newKeySet();
     }
 
     public void addEntity(GameEntity<?> entity) {
-        if (this.getEntities().contains(entity)) {
+        if (this.entities.contains(entity)) {
             return;
         }
-        this.getEntities().add(entity);
-        this.getNewEntities().add(entity);
-        this.hasNewEntities = true;
+        this.entities.add(entity);
+        if (this.notContainEntities.remove(entity)) {
+            this.newEntities.add(entity);
+            this.hasNewEntities = true;
+        }
     }
 
     @Override
@@ -46,29 +50,25 @@ public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
         return getConfigId();
     }
 
-    public boolean hasNewEntities() {
-        return hasNewEntities;
-    }
-
     public void resetNewEntities() {
-        hasNewEntities = false;
-        newEntities.clear();
-    }
-
-    public void removeEntity(int entityId) {
-        this.getEntities().removeIf(e-> e.getId() == entityId);
-        this.entityLeave = true;
+        this.hasNewEntities = false;
+        this.newEntities.clear();
     }
 
     public void removeEntity(GameEntity entity) {
-        this.getEntities().remove(entity);
-        this.getLeftEntities().add(entity);
-        this.entityLeave = true;
+        if (this.notContainEntities.contains(entity)) {
+            return;
+        }
+        this.notContainEntities.add(entity);
+        if (this.entities.remove(entity)) {
+            this.leftEntities.add(entity);
+            this.entityLeave = true;
+        }
     }
-    public boolean entityLeave() {return this.entityLeave;}
+
     public void resetEntityLeave() {
         this.entityLeave = false;
-        leftEntities.clear();
+        this.leftEntities.clear();
     }
 
     public boolean isPosInRegion(Vector position) {

--- a/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
@@ -13,6 +13,7 @@ import org.anime_game_servers.gi_lua.models.scene.group.SceneRegion;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @Getter
 public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
@@ -71,9 +72,18 @@ public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
         this.leftEntities.clear();
     }
 
+    public void clearDeadEntities() {
+        entities.removeAll(entities.stream()
+            .filter(entity -> this.getScene().getEntityById(entity.id) == null)
+            .collect(Collectors.toSet()));
+        notContainEntities.removeAll(notContainEntities.stream()
+            .filter(entity -> this.getScene().getEntityById(entity.id) == null)
+            .collect(Collectors.toSet()));
+    }
+
     public boolean isPosInRegion(Vector position) {
         val initialDataSource = getSpawnConfig().getInitDataSource();
-        if(initialDataSource instanceof SceneRegion region){
+        if (initialDataSource instanceof SceneRegion region) {
             return region.contains(position);
         }
         return false;

--- a/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
@@ -20,10 +20,10 @@ public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
     private final Position position;
     private boolean hasNewEntities;
     private boolean entityLeave;
-    private final Set<GameEntity> entities; // Ids of entities inside this region
-    private final Set<GameEntity> notContainEntities; // Ids of entities outside this region
-    private final Set<GameEntity> newEntities; // Ids that entered this region since the last check
-    private final Set<GameEntity> leftEntities; // Ids that left this region since the last check
+    private final Set<GameEntity<?>> entities; // Ids of entities inside this region
+    private final Set<GameEntity<?>> notContainEntities; // Ids of entities outside this region
+    private final Set<GameEntity<?>> newEntities; // Ids that entered this region since the last check
+    private final Set<GameEntity<?>> leftEntities; // Ids that left this region since the last check
 
     public EntityRegion(Scene scene, CreateRegionEntityConfig createConfig) {
         super(scene, createConfig);
@@ -56,7 +56,7 @@ public class EntityRegion extends GameEntity<CreateRegionEntityConfig> {
         this.newEntities.clear();
     }
 
-    public void removeEntity(GameEntity entity) {
+    public void removeEntity(GameEntity<?> entity) {
         if (this.notContainEntities.contains(entity)) {
             return;
         }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -590,6 +590,8 @@ public class SceneScriptManager {
         }
 
         for (var region : this.regions.values()) {
+            region.clearDeadEntities();
+
             getScene().getEntities().values().stream()
                 .filter(e -> e.getEntityType() == EntityType.Avatar)
                 .filter(e -> region.isPosInRegion(e.getPosition()) && !region.getEntities().contains(e))

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -11,6 +11,7 @@ import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
 import emu.grasscutter.game.entity.create_config.CreateMonsterEntityConfig;
 import emu.grasscutter.game.entity.create_config.CreateNpcEntityConfig;
 import emu.grasscutter.game.entity.create_config.CreateRegionEntityConfig;
+import emu.grasscutter.game.props.EntityType;
 import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestGroupSuite;
 import emu.grasscutter.game.quest.enums.QuestCond;
@@ -590,11 +591,13 @@ public class SceneScriptManager {
 
         for (var region : this.regions.values()) {
             getScene().getEntities().values().stream()
+                .filter(e -> e.getEntityType() == EntityType.Avatar)
                 .filter(e -> region.isPosInRegion(e.getPosition()) && !region.getEntities().contains(e))
                 .forEach(region::addEntity);
 
-            region.getEntities().stream()
-                .filter(e -> !region.isPosInRegion(e.getPosition()))
+            getScene().getEntities().values().stream()
+                .filter(e -> e.getEntityType() == EntityType.Avatar)
+                .filter(e -> !region.isPosInRegion(e.getPosition()) && !region.getNotContainEntities().contains(e))
                 .forEach(region::removeEntity);
 
             // call enter region events for new entities

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -612,7 +612,7 @@ public class SceneScriptManager {
         }
     }
 
-    private void callRegionEvent(EntityRegion region, int eventType, GameEntity entity) {
+    private void callRegionEvent(EntityRegion region, int eventType, GameEntity<?> entity) {
         callEvent(new ScriptArgs(region.getGroupId(), eventType, region.getConfigId())
             .setEventSource(entity.getEntityType().getValue())
             .setSourceEntityId(region.getId())
@@ -966,20 +966,20 @@ public class SceneScriptManager {
         return entity;
     }
 
-    public void addEntity(GameEntity gameEntity) {
+    public void addEntity(GameEntity<?> gameEntity) {
         getScene().addEntity(gameEntity);
     }
 
-    public void meetEntities(List<? extends GameEntity> gameEntity) {
+    public void meetEntities(List<? extends GameEntity<?>> gameEntity) {
         getScene().addEntities(gameEntity, VisionType.VISION_MEET);
     }
 
-    public void addEntities(List<? extends GameEntity> gameEntity) {
+    public void addEntities(List<? extends GameEntity<?>> gameEntity) {
         getScene().addEntities(gameEntity);
     }
 
-    public void removeEntities(List<? extends GameEntity> gameEntity) {
-        getScene().removeEntities(gameEntity.stream().map(e -> (GameEntity) e).collect(Collectors.toList()), VisionType.VISION_REFRESH);
+    public void removeEntities(List<? extends GameEntity<?>> gameEntity) {
+        getScene().removeEntities(gameEntity.stream().map(e -> (GameEntity<?>) e).collect(Collectors.toList()), VisionType.VISION_REFRESH);
     }
 
     public void removeMonstersInGroup(SceneGroup group, SceneSuite suite) {


### PR DESCRIPTION
## Description
Entities spawning inside of regions caused the regions to trigger. This was particularly bad in the chasm where paimon give some tips about babbling rocks. the region is in group 166001385, and it is triggered by a mushroom in group 166001308.
There are other affected groups. groups where you are supposed to follow a trail of gadgets, but the regions centered on those gadgets are triggered by the gadgets!

The old definitions of leaving and entering a region used to roughly be:
If something is inside a region and it had not been marked as inside the region in the previous tick, trigger enter region.
If something was marked as inside a region and now is outside the region, trigger leave region.

As an edge case, this triggered enter region when an entity spawns inside a region, or a region spawns around and entity.

I have redefined it as follows:
If something was marked outside a region and moved into a region, trigger enter region.
If something was marked inside a region and moved outside a region, trigger leave region.

Basically, I have made the definitions of enter region and leave region symmetrical.


By request, I have tacked on code that regions can only be triggered by avatars. This renders all of the above moot. :/

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.