### PR TITLE
Implement ExecUnlockPlayerWorldScene

### DIFF
--- a/src/main/java/emu/grasscutter/config/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/config/ConfigContainer.java
@@ -253,6 +253,7 @@ public class ConfigContainer {
         public ResinOptions resinOptions = new ResinOptions();
         public Rates rates = new Rates();
         public boolean questing = false;
+        public boolean lockScenesByDefault = true;
 
         public static class InventoryLimits {
             public int weapons = 2000;

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -150,6 +150,7 @@ public class Player {
     @Getter private Map<Integer, Integer> questGlobalVariables;
     @Getter private Map<Integer, Integer> openStates;
     @Getter private Map<Integer, Map<Integer, Boolean>> sceneTags;
+    @Getter @Setter private Map<Integer, Boolean> unlockedScenes;
     @Getter @Setter private Map<Integer, Set<Integer>> unlockedSceneAreas;
     @Getter @Setter private Map<Integer, Set<Integer>> unlockedScenePoints;
     @Getter @Setter private List<Integer> chatEmojiIdList;
@@ -276,6 +277,7 @@ public class Player {
         this.questGlobalVariables = new HashMap<>();
         this.openStates = new HashMap<>();
         this.sceneTags = new HashMap<>();
+        this.unlockedScenes = new HashMap<>();
         this.unlockedSceneAreas = new HashMap<>();
         this.unlockedScenePoints = new HashMap<>();
         this.chatEmojiIdList = new ArrayList<>();

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecUnlockPlayerWorldScene.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecUnlockPlayerWorldScene.java
@@ -1,0 +1,23 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.common.quest.SubQuestData.QuestExecParam;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import emu.grasscutter.server.packet.send.PacketPlayerWorldSceneInfoListNotify;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_UNLOCK_PLAYER_WORLD_SCENE)
+public class ExecUnlockPlayerWorldScene extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
+        int sceneId = Integer.parseInt(paramStr[0]);
+
+        //set the scene to locked: false
+        quest.getOwner().getUnlockedScenes().put(sceneId, false);
+
+        //send a new PlayerWorldSceneInfoListNotify
+        quest.getOwner().getSession().send(new PacketPlayerWorldSceneInfoListNotify(quest.getOwner()));
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerWorldSceneInfoListNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerWorldSceneInfoListNotify.java
@@ -1,11 +1,13 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.config.Configuration;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.SceneType;
 import emu.grasscutter.net.packet.BaseTypedPacket;
-import org.anime_game_servers.multi_proto.gi.messages.scene.PlayerWorldSceneInfoListNotify;
 import org.anime_game_servers.multi_proto.gi.messages.scene.PlayerWorldSceneInfo;
+import org.anime_game_servers.multi_proto.gi.messages.scene.PlayerWorldSceneInfoListNotify;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +23,9 @@ public class PacketPlayerWorldSceneInfoListNotify extends BaseTypedPacket<Player
             if (scene.getSceneType() != SceneType.SCENE_WORLD) continue;
 
             var worldInfoBuilder = new PlayerWorldSceneInfo();
+            var isSceneLocked = player.getUnlockedScenes()
+                .computeIfAbsent(scene.getId(), k -> Configuration.GAME_OPTIONS.lockScenesByDefault);
+            worldInfoBuilder.setLocked(isSceneLocked);
             worldInfoBuilder.setSceneId(scene.getId());
 
             worldInfoBuilder.setSceneTagIdList(player.getSceneTagList(scene.getId()));


### PR DESCRIPTION
## Description
ExecUnlockPlayerWorldScene unlocks a scene. A scene being unlocked means it is accessible via the in-game map.
Grasscutter's teleportation is not affected by scene locking.

All scenes I have visited marked as unlocked:
![image](https://github.com/user-attachments/assets/93218b96-d80b-497a-9c07-538179922862)

All scenes I have visited marked as locked:
![image](https://github.com/user-attachments/assets/158dcf56-55f9-4fae-9eaf-d882bdedad2a)

I have added an option in the config for this, since it might make going to scenes you have visited harder for devs.


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.