### PR TITLE
Make tutorial quest work

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/content/ContentTriggerFire.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentTriggerFire.java
@@ -1,9 +1,19 @@
 package emu.grasscutter.game.quest.content;
 
+import emu.grasscutter.data.common.quest.SubQuestData;
 import emu.grasscutter.game.quest.QuestValueContent;
+import emu.grasscutter.game.quest.enums.QuestContent;
 
 import static emu.grasscutter.game.quest.enums.QuestContent.QUEST_CONTENT_TRIGGER_FIRE;
 
 @QuestValueContent(QUEST_CONTENT_TRIGGER_FIRE)
 public class ContentTriggerFire extends BaseContent {
+    @Override
+    public boolean isEvent(SubQuestData questData, SubQuestData.QuestContentCondition condition, QuestContent type, String paramStr, int... params) {
+        // this is trigger by entering a scene region
+        // How it works: a Lua function (e.g. `condition_EVENT_ENTER_REGION_84`) is invoked
+        // if it returns true, this event should be triggered for some on-going quest
+        // NOTE: The returned value is already checked elsewhere
+        return condition.getType() == type;
+    }
 }

--- a/src/main/java/emu/grasscutter/scripts/StaticScriptLibHandler.java
+++ b/src/main/java/emu/grasscutter/scripts/StaticScriptLibHandler.java
@@ -16,7 +16,7 @@ public class StaticScriptLibHandler implements ScriptLibStaticHandler {
     }
 
     @Override
-    public int GetEntityType(int entityId) {
+    public int GetEntityType(LuaContext luaContext, int entityId) {
         return EntityIdType.fromEntityId(entityId).getType().getValue();
     }
 


### PR DESCRIPTION
## Description

I don't see the main repo got updated in a while. Glad to find this active repo.

After setting up without any help from documentation, I was able to run my own private server for development.
I configured it to run with version 5.3. After trying out, it bugged me that the tutorial quest does not work.
- After the cutscene, Paimon just stand there (quest progressed from 35104 (cutscene) -> 35100 (go to paimon)).
- The quest does not show below the minimap. When I progressed quest to 353 main quest (where we meet Venti in the forest), it does show.
  (it should look like this)
  ![image](https://github.com/user-attachments/assets/c462e361-7473-4208-b3ed-36e15baddb26)
- The quest does not show in quest menu until log out and log in again.

The quest was stuck at 35100, but after I fixed the `QUEST_CONTENT_TRIGGER_FIRE` condition, it can be progressed to 35101, but still need to logout and login again for it to progress.

My guess is that some packets are still wrong or missing (or maybe my configs/resources are wrong). I found the following related to quests:
- FinishedParentQuestNotify
- QuestListNotify
- AddQuestContentProgressRsp
- QuestProgressUpdateNotify
- QuestListUpdateNotify
- ServerCondMeetQuestListUpdateNotify

Many things are still unclear to me. Could someone provide more information on how quests work and/or some packet dump from official? (else I need to spawn my own GIO server to capture them).

Note that I added `context` parameter to the `ScriptLib.GetEntityType`, because I use resources from https://gitlab.com/YuukiPS/GC-Resources/-/blob/5.0/Resources/Scripts/Scene/3/scene3_group133003901.lua (scripts v3.2 don't have that parameter).

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.