### PR TITLE
Small Ability Fixes

### DIFF
--- a/src/main/java/emu/grasscutter/GameConstants.java
+++ b/src/main/java/emu/grasscutter/GameConstants.java
@@ -1,12 +1,12 @@
 package emu.grasscutter;
 
+import emu.grasscutter.utils.Position;
+import emu.grasscutter.utils.Utils;
+
 import java.time.DayOfWeek;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-
-import emu.grasscutter.utils.Position;
-import emu.grasscutter.utils.Utils;
 
 public final class GameConstants {
     public static String VERSION = "3.2.0";
@@ -39,8 +39,16 @@ public final class GameConstants {
 
     // Default entity ability hashes.
     public static final String[] DEFAULT_ABILITY_STRINGS = {
-        "Avatar_DefaultAbility_VisionReplaceDieInvincible", "Avatar_DefaultAbility_AvartarInShaderChange", "Avatar_SprintBS_Invincible",
-        "Avatar_Freeze_Duration_Reducer", "Avatar_Attack_ReviveEnergy", "Avatar_Component_Initializer", "Avatar_FallAnthem_Achievement_Listener"
+        "Avatar_DefaultAbility_VisionReplaceDieInvincible",
+        "Avatar_DefaultAbility_AvartarInShaderChange",
+        "Avatar_SprintBS_Invincible",
+        "Avatar_Freeze_Duration_Reducer",
+        "Avatar_Attack_ReviveEnergy",
+        "Avatar_Component_Initializer",
+        "Avatar_HDMesh_Controller",
+        "Avatar_Trampoline_Jump_Controller",
+        "Avatar_ArkheGrade_CD_Controller",
+        "Avatar_TriggerNyxInstant"
     };
     public static final int[] DEFAULT_ABILITY_HASHES = Arrays.stream(DEFAULT_ABILITY_STRINGS).mapToInt(Utils::abilityHash).toArray();
     public static final int DEFAULT_ABILITY_NAME = Utils.abilityHash("Default");

--- a/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
+++ b/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
@@ -1,11 +1,10 @@
 package emu.grasscutter.data.binout;
 
-import java.io.Serializable;
-
 import com.google.gson.annotations.SerializedName;
-
 import emu.grasscutter.data.common.DynamicFloat;
 import emu.grasscutter.game.props.ElementType;
+
+import java.io.Serializable;
 
 public class AbilityModifier implements Serializable {
     private static final long serialVersionUID = -2001232313615923575L;
@@ -146,9 +145,16 @@ public class AbilityModifier implements Serializable {
         public DynamicFloat valueRangeMax;
         public String overrideMapKey;
 
-        public int param1;
-        public int param2;
-        public int param3;
+        public int paramNum;
+        public DynamicFloat param1 = DynamicFloat.ZERO;
+        public DynamicFloat param2 = DynamicFloat.ZERO;
+        public DynamicFloat param3 = DynamicFloat.ZERO;
+
+        public String luaCallType;
+        public String funcName;
+        public String sourceName;
+        @SerializedName(value = "callParamList", alternate = "CallParamList")
+        public int[] callParamList;
 
         public enum DropType {
             LevelControl,

--- a/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
+++ b/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
@@ -1,16 +1,7 @@
 package emu.grasscutter.game.ability;
 
-import java.util.HashMap;
-import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.Loggers;
-import emu.grasscutter.game.props.ElementReactionType;
-
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.AbilityData;
 import emu.grasscutter.data.binout.AbilityMixinData;
@@ -23,6 +14,7 @@ import emu.grasscutter.game.ability.mixins.AbilityMixinHandler;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.player.BasePlayerManager;
 import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.props.ElementReactionType;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import lombok.Getter;
 import lombok.val;
@@ -38,6 +30,13 @@ import org.anime_game_servers.multi_proto.gi.messages.general.ability.AbilityStr
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 
 public final class AbilityManager extends BasePlayerManager {
     @Getter
@@ -378,7 +377,7 @@ public final class AbilityManager extends BasePlayerManager {
             }
 
             if(instancedAbilityData == null ||  instancedAbilityData.modifiers == null) {
-                logger.info("No ability found");
+                logger.info("No ability found. modChange: {}", modChange);
                 return; //TODO: Display error message
             }
 
@@ -422,6 +421,10 @@ public final class AbilityManager extends BasePlayerManager {
 
     @Nullable
     private String getAbilityName(AbilityString protoString) {
+        if (protoString == null) {
+            Grasscutter.getLogger().error("null protoString!");
+            return null;
+        }
         if(protoString.getType() instanceof AbilityString.Type.Str str){
             return str.getValue();
         } else if (protoString.getType() instanceof AbilityString.Type.Hash hash){

--- a/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
+++ b/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
@@ -72,7 +72,7 @@ public final class AbilityManager extends BasePlayerManager {
                     return;
                 }
             } catch (Exception e) {
-                logger.error("Unable to register handler.", e);
+                logger.error("Unable to register handlerClassesAction.", e);
             }
         }
 
@@ -87,7 +87,7 @@ public final class AbilityManager extends BasePlayerManager {
                     return;
                 }
             } catch (Exception e) {
-                logger.error("Unable to register handler.", e);
+                logger.error("Unable to register handlerClassesMixin.", e);
             }
         }
     }
@@ -96,13 +96,13 @@ public final class AbilityManager extends BasePlayerManager {
         AbilityActionHandler handler = actionHandlers.get(action.type);
 
         if (handler == null || ability == null) {
-            logger.error("Could not execute ability action {} at {}", action.type, ability);
+            logger.error("executeAction could not execute ability action {} at {}", action.type, ability);
             return;
         }
 
         eventExecutor.submit(() -> {
             if (!handler.execute(ability, action, abilityData, target)) {
-                logger.error("exec ability action failed {} at {}", action.type, ability);
+                logger.error("executeAction exec ability action failed {} at {}", action.type, ability);
             }
         });
     }
@@ -111,25 +111,25 @@ public final class AbilityManager extends BasePlayerManager {
         AbilityMixinHandler handler = mixinHandlers.get(mixinData.type);
 
         if (handler == null || ability == null || mixinData == null) {
-            logger.error("Could not execute ability mixin {} at {}", mixinData.type, ability);
+            logger.error("executeMixin could not execute ability mixin {} at {}", mixinData.type, ability);
             return;
         }
 
         eventExecutor.submit(() -> {
             if (!handler.execute(ability, mixinData, abilityData)) {
-                logger.error("exec ability action failed {} at {}", mixinData.type, ability);
+                logger.error("executeMixin exec ability action failed {} at {}", mixinData.type, ability);
             }
         });
     }
 
     public void onAbilityInvoke(AbilityInvokeEntry invoke) throws Exception {
-        logger.debug("Ability invoke: " + invoke + " " + invoke.getArgumentType() + " (" + invoke.getArgumentType() + "): " + this.player.getScene().getEntityById(invoke.getEntityId()));
+        logger.debug("Ability invoke: {} {} ({}): {}", invoke, invoke.getArgumentType(), invoke.getArgumentType(), this.player.getScene().getEntityById(invoke.getEntityId()));
         var entity = this.player.getScene().getEntityById(invoke.getEntityId());
         if(entity != null) {
             logger.debug("Entity group id {} config id {}", entity.getGroupId(), entity.getConfigId());
         }
         if(invoke.getHead() != null && invoke.getHead().getTargetId() != 0) {
-            logger.debug("Target: " + this.player.getScene().getEntityById(invoke.getHead().getTargetId()));
+            logger.debug("Target: {}", this.player.getScene().getEntityById(invoke.getHead().getTargetId()));
         }
 
         if(invoke.getHead() != null && invoke.getHead().getLocalId() != 0) {
@@ -156,7 +156,7 @@ public final class AbilityManager extends BasePlayerManager {
 
         var entity = this.player.getScene().getEntityById(invoke.getEntityId());
         if(entity == null) {
-            logger.info("Entity not found: {}", invoke.getEntityId());
+            logger.info("handleServerInvoke entity not found: {}", invoke.getEntityId());
             return;
         }
 
@@ -177,7 +177,7 @@ public final class AbilityManager extends BasePlayerManager {
         }
 
         if(ability == null) {
-            logger.warn("Ability not found: ability {} modifier {}", head.getInstancedAbilityId(), head.getInstancedModifierId());
+            logger.warn("handleServerInvoke ability not found: ability {} modifier {}", head.getInstancedAbilityId(), head.getInstancedModifierId());
             return;
         }
 
@@ -254,13 +254,13 @@ public final class AbilityManager extends BasePlayerManager {
 
     private void setAbilityOverrideValue(Ability ability, AbilityScalarValueEntry valueChange) {
         if(valueChange.getValueType() != AbilityScalarType.ABILITY_SCALAR_TYPE_FLOAT) {
-            logger.info("Scalar type not supported: {}", valueChange.getValueType());
+            logger.info("setAbilityOverrideValue scalar type not supported: {}", valueChange.getValueType());
 
             return;
         }
 
         if(valueChange.getKey() == null){
-            logger.warn("Key is null");
+            logger.warn("setAbilityOverrideValue key is null");
             return;
         }
 
@@ -282,13 +282,13 @@ public final class AbilityManager extends BasePlayerManager {
         var head = invoke.getHead();
 
         if(entity == null) {
-            logger.info("Entity not found: {}", invoke.getEntityId());
+            logger.info("handleOverrideParam entity not found: {}", invoke.getEntityId());
             return;
         }
 
         var instancedAbilityIndex = head.getInstancedAbilityId() - 1;
         if(instancedAbilityIndex >= entity.getInstancedAbilities().size()) {
-            logger.error("Ability not found {}", head.getInstancedAbilityId());
+            logger.error("handleOverrideParam ability not found {}", head.getInstancedAbilityId());
             return;
         }
 
@@ -303,13 +303,13 @@ public final class AbilityManager extends BasePlayerManager {
         var head = invoke.getHead();
 
         if(entity == null) {
-            logger.info("Entity not found: {}", invoke.getEntityId());
+            logger.info("handleReinitOverrideMap entity not found: {}", invoke.getEntityId());
             return;
         }
 
         var instancedAbilityIndex = head.getInstancedAbilityId() - 1;
         if(instancedAbilityIndex >= entity.getInstancedAbilities().size()) {
-            logger.error("Ability not found {}", head.getInstancedAbilityId());
+            logger.error("handleReinitOverrideMap ability not found {}", head.getInstancedAbilityId());
             return;
         }
 
@@ -336,7 +336,7 @@ public final class AbilityManager extends BasePlayerManager {
 
         var entity = this.player.getScene().getEntityById(invoke.getEntityId());
         if(entity == null){
-            logger.warn("Entity not found: {}", invoke.getEntityId());
+            logger.warn("handleModifierChange entity not found: {}", invoke.getEntityId());
             return;
         }
 
@@ -377,14 +377,14 @@ public final class AbilityManager extends BasePlayerManager {
             }
 
             if(instancedAbilityData == null ||  instancedAbilityData.modifiers == null) {
-                logger.info("No ability found. modChange: {}", modChange);
+                logger.info("handleModifierChange No ability found. modChange: {}", modChange);
                 return; //TODO: Display error message
             }
 
             var modifierArray = instancedAbilityData.modifiers.values().toArray();
             if(modChange.getModifierLocalId() >= modifierArray.length)
             {
-                logger.info("Modifier local id {} not found", modChange.getModifierLocalId());
+                logger.info("handleModifierChange modifier local id {} not found", modChange.getModifierLocalId());
                 return;
             }
             var modifierData = (AbilityModifier)modifierArray[modChange.getModifierLocalId()];
@@ -407,7 +407,7 @@ public final class AbilityManager extends BasePlayerManager {
             entity.getInstancedModifiers().remove(head.getInstancedModifierId());
         } else {
             //TODO: Display error message
-            logger.debug("Unknown action");
+            logger.debug("handleModifierChange unknown action");
         }
     }
 
@@ -474,7 +474,7 @@ public final class AbilityManager extends BasePlayerManager {
         var entity = this.player.getScene().getEntityById(invoke.getEntityId());
 
         if(entity == null) {
-            logger.info("Entity not found: {}", invoke.getEntityId());
+            logger.info("handleAddNewAbility entity not found: {}", invoke.getEntityId());
             return;
         }
 
@@ -484,7 +484,7 @@ public final class AbilityManager extends BasePlayerManager {
 
         var ability = GameData.getAbilityData(abilityName);
         if(ability == null) {
-            logger.info("Ability not found: {}", abilityName);
+            logger.info("handleAddNewAbility ability not found: {}", abilityName);
             return;
         }
 

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionExecuteGadgetLua.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionExecuteGadgetLua.java
@@ -10,10 +10,21 @@ public class ActionExecuteGadgetLua extends AbilityActionHandler {
     public boolean execute(Ability ability, AbilityModifierAction action,byte[]  abilityData, GameEntity<?> target) {
         GameEntity owner = ability.getOwner();
 
-        //Investigate if we need to use target
-
         if(owner.getEntityController() != null) {
-            owner.getEntityController().onClientExecuteRequest(owner, action.param1, action.param2, action.param3);
+            owner.getEntityController().onClientExecuteRequest(owner,
+                (int) action.param1.get(ability),
+                (int) action.param2.get(ability),
+                (int) action.param3.get(ability)
+            );
+            return true;
+        }
+
+        if (target.getEntityController() != null) {
+            target.getEntityController().onClientExecuteRequest(target,
+                (int) action.param1.get(ability),
+                (int) action.param2.get(ability),
+                (int) action.param3.get(ability)
+            );
             return true;
         }
 

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionServerLuaCall.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionServerLuaCall.java
@@ -1,0 +1,55 @@
+package emu.grasscutter.game.ability.actions;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
+import emu.grasscutter.game.ability.Ability;
+import emu.grasscutter.game.entity.GameEntity;
+import emu.grasscutter.scripts.lua_engine.GroupEventLuaContext;
+import lombok.val;
+import org.anime_game_servers.gi_lua.models.ScriptArgs;
+
+@AbilityAction(AbilityModifierAction.Type.ServerLuaCall)
+public class ActionServerLuaCall extends AbilityActionHandler {
+    @Override
+    public boolean execute(Ability ability, AbilityModifierAction action, byte[] abilityData, GameEntity target) {
+        switch (action.luaCallType) {
+            case "FromGroup" -> {
+                return serverLuaCallForGroup(target.getGroupId(), ability, action, abilityData, target);
+            }
+            case "SpecificGroup" -> {
+                var returnBool = true;
+                for (val groupId : action.callParamList) {
+                    returnBool = returnBool && serverLuaCallForGroup(groupId, ability, action, abilityData, target);
+                }
+                return returnBool;
+            }
+            default -> {
+                Grasscutter.getLogger().error("Unimplemented ActionServerLuaCall {}", action.luaCallType);
+//                "AbilityGroupSourceGroup"
+//                "CurChallengeGroup"
+//                "CurGalleryControlGroup"
+//                "CurRogueBossGroup"
+//                "CurScenePlay"
+            }
+        }
+        return false;
+    }
+
+    private boolean serverLuaCallForGroup(int groupId, Ability ability, AbilityModifierAction action, byte[] abilityData, GameEntity target) {
+        val scriptManager = target.getScene().getScriptManager();
+        val scriptArgs = new ScriptArgs(groupId, 0)
+            .setTargetEntityId(target.getId())
+            .setSourceEntityId(target.getId());
+        val paramsCount = action.paramNum;
+        val scriptParams = new Integer[paramsCount];
+        switch (paramsCount) {
+            case 3:
+                scriptParams[2] = (int) action.param3.get(ability);
+            case 2:
+                scriptParams[1] = (int) action.param2.get(ability);
+            case 1:
+                scriptParams[0] = (int) action.param1.get(ability);
+        }
+        return scriptManager.callGroupLuaFunction(action.funcName, scriptArgs, (Object[]) scriptParams);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionServerLuaTriggerEvent.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionServerLuaTriggerEvent.java
@@ -1,0 +1,50 @@
+package emu.grasscutter.game.ability.actions;
+
+import com.github.davidmoten.guavamini.Lists;
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
+import emu.grasscutter.game.ability.Ability;
+import emu.grasscutter.game.entity.GameEntity;
+import lombok.val;
+import org.anime_game_servers.gi_lua.models.ScriptArgs;
+import org.anime_game_servers.gi_lua.models.constants.EventType;
+
+import java.util.Arrays;
+
+@AbilityAction(AbilityModifierAction.Type.ServerLuaTriggerEvent)
+public class ActionServerLuaTriggerEvent extends AbilityActionHandler {
+
+    @Override
+    public boolean execute(Ability ability, AbilityModifierAction action, byte[] abilityData, GameEntity target) {
+        val scene = target.getScene();
+        val scriptManager = scene.getScriptManager();
+
+        val params = switch (action.luaCallType) {
+            case "FromGroup" -> {
+                var groupId = target.getGroupId();
+                yield Lists.newArrayList(new ScriptArgs(groupId, EventType.EVENT_LUA_NOTIFY));
+            }
+            case "SpecificGroup" -> Arrays.stream(action.callParamList)
+                .mapToObj(groupId -> new ScriptArgs(groupId, EventType.EVENT_LUA_NOTIFY))
+                .toList();
+            default -> {
+                Grasscutter.getLogger().error("Unimplemented ActionServerLuaCall {}", action.luaCallType);
+                yield null;
+            }
+        };
+
+        if(params == null) return false;
+        params.forEach(p -> {
+            p.setTargetEntityId(target.getId());
+            p.setSourceEntityId(target.getId());
+            p.setEventSource(action.sourceName);
+
+            p.setParam1( (int) action.param1.get(ability));
+            p.setParam2( (int) action.param2.get(ability));
+            p.setParam3( (int) action.param3.get(ability));
+
+            scriptManager.callEvent(p);
+        });
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -807,6 +807,42 @@ public class SceneScriptManager {
         }
     }
 
+    public boolean callGroupLuaFunction(String funcName, ScriptArgs params, Object... args) {
+        val groupId = params.groupId;
+        val group = getGroupById(groupId);
+        if (group == null) {
+            logger.error("callLuaFunction group is null");
+            return false;
+        }
+
+        val script = group.getScript();
+        if (script == null) {
+            logger.warn("callScriptFunc script is null");
+            return false;
+        }
+
+        if (funcName.isEmpty()) {
+            logger.warn("callScriptFunc funcName is empty");
+            return false;
+        }
+        if (!script.hasMethod(funcName)) {
+            logger.warn("callScriptFunc script has no method {}", funcName);
+            return false;
+        }
+
+        val context = new GroupEventLuaContext(script.getEngine(), group, params, this);
+        try {
+            val luaArgs = new Object[args.length + 1];
+            luaArgs[0] = context;
+            System.arraycopy(args, 0, luaArgs, 1, args.length);
+            val result = script.callMethod(funcName, luaArgs);
+            return true;
+        } catch (RuntimeException | ScriptException | NoSuchMethodException error) {
+            logger.error("[LUA] call trigger failed in group {} with {},{}", group.getGroupInfo().getId(), funcName, params, error);
+            return false;
+        }
+    }
+
     private LuaValue callScriptFunc(@Nonnull String funcName, SceneGroup group, ScriptArgs params) {
         val script = group.getScript();
         if(script==null){

--- a/src/main/java/emu/grasscutter/scripts/lua_engine/GroupEventLuaContext.java
+++ b/src/main/java/emu/grasscutter/scripts/lua_engine/GroupEventLuaContext.java
@@ -16,6 +16,9 @@ public class GroupEventLuaContext implements org.anime_game_servers.gi_lua.scrip
     @Getter
     final private ScriptArgs args;
 
+    public int target_entity_id;
+    public int source_entity_id;
+
     final private SceneScriptManager scriptManager;
 
     @Getter(onMethod = @__(@Override))
@@ -26,6 +29,8 @@ public class GroupEventLuaContext implements org.anime_game_servers.gi_lua.scrip
         this.args = args;
         this.scriptManager = scriptManager;
         this.engine = engine;
+        this.target_entity_id = args.getTargetEntityId();
+        this.source_entity_id = args.getSourceEntityId();
     }
 
     public SceneGroup getCurrentGroup() {

--- a/src/main/java/emu/grasscutter/scripts/scriptlib_handlers/BaseHandler.java
+++ b/src/main/java/emu/grasscutter/scripts/scriptlib_handlers/BaseHandler.java
@@ -3,10 +3,12 @@ package emu.grasscutter.scripts.scriptlib_handlers;
 import emu.grasscutter.Loggers;
 import emu.grasscutter.scripts.lua_engine.GroupEventLuaContext;
 import lombok.Getter;
+import lombok.val;
 import org.anime_game_servers.gi_lua.models.scene.group.SceneGroup;
 import org.slf4j.Logger;
 
 import java.util.Arrays;
+import java.util.Set;
 
 import static java.lang.StackWalker.Option.RETAIN_CLASS_REFERENCE;
 
@@ -15,7 +17,8 @@ public class BaseHandler {
     private static final Logger logger = Loggers.getScriptSystem();
 
     protected int handleUnimplemented(Object... args){
-        logger.warn("[LUA] Call unimplemented {} with {}", StackWalker.getInstance(RETAIN_CLASS_REFERENCE).getCallerClass(), Arrays.toString(args));
+        val methodName = StackWalker.getInstance(Set.of(RETAIN_CLASS_REFERENCE)).walk(s -> s.limit(2).toList().get(1)).getMethodName();
+        logger.warn("[LUA] Call unimplemented {} with {}", methodName, Arrays.toString(args));
         return 0;
     }
 

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -1,9 +1,5 @@
 package emu.grasscutter.server.game;
 
-import java.io.File;
-import java.net.InetSocketAddress;
-import java.nio.file.Path;
-
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.Grasscutter.ServerDebugMode;
 import emu.grasscutter.game.Account;
@@ -24,7 +20,12 @@ import org.anime_game_servers.multi_proto.core.interfaces.PacketIdProvider;
 import org.anime_game_servers.multi_proto.gi.packet_id.PacketIds;
 import org.anime_game_servers.multi_proto.gi.utils.VersionIdentify;
 
-import static emu.grasscutter.config.Configuration.*;
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+
+import static emu.grasscutter.config.Configuration.GAME_INFO;
+import static emu.grasscutter.config.Configuration.SERVER;
 import static emu.grasscutter.utils.Language.translate;
 
 public class GameSession implements GameSessionManager.KcpChannel {
@@ -109,14 +110,16 @@ public class GameSession implements GameSessionManager.KcpChannel {
 
     public void send(BasePacket packet) {
         // Test
-        if (packet.getOpcode(this) <= 0) {
+        val opcode = packet.getOpcode(this);
+        if (opcode <= 0) {
             Grasscutter.getLogger().warn("Tried to send packet with missing cmd id!");
             return;
         }
 
         // DO NOT REMOVE (unless we find a way to validate code before sending to client which I don't think we can)
         // Stop WindSeedClientNotify from being sent for security purposes.
-        if (PacketOpcodesUtils.BANNED_PACKETS.contains(packet.getOpcode(this))) {
+        val paketName = PacketOpcodesUtils.getOpcodeName(opcode, this);
+        if (PacketOpcodesUtils.BANNED_PACKETS.contains(paketName)) {
             return;
         }
 
@@ -126,21 +129,20 @@ public class GameSession implements GameSessionManager.KcpChannel {
         }
 
         // Log
-        val paketName = PacketOpcodesUtils.getOpcodeName(packet.getOpcode(this), this);
         switch (GAME_INFO.logPackets) {
             case ALL -> {
                 if (!PacketOpcodesUtils.LOOP_PACKETS.contains(paketName) || GAME_INFO.isShowLoopPackets) {
-                    logPacket("SEND", packet.getOpcode(this), packet.getData(version));
+                    logPacket("SEND", opcode, packet.getData(version));
                 }
             }
             case WHITELIST -> {
                 if (SERVER.debugWhitelist.contains(paketName)) {
-                    logPacket("SEND", packet.getOpcode(this), packet.getData(version));
+                    logPacket("SEND", opcode, packet.getData(version));
                 }
             }
             case BLACKLIST -> {
                 if (!SERVER.debugBlacklist.contains(paketName)) {
-                    logPacket("SEND", packet.getOpcode(this), packet.getData(version));
+                    logPacket("SEND", opcode, packet.getData(version));
                 }
             }
             default -> {


### PR DESCRIPTION
## Description
GameConstants.java -> 
"Avatar_Trampoline_Jump_Controller" is needed to make bouncy mushrooms work. 
Added other things in the same area. Let me know if that is unwise.

AbilityModifier.java ->
Added luaCallType and funcName so I can use those in ActionServerLuaCall.
Changed params to DynamicFloat.

AbilityManager.java ->
Handled a nurupo that protoString was making.
Added modChange printing for flavor.

ActionExecuteGadgetLua.java ->
When it can't owner, make it target instead. More research is gonna happen tomorrow.

ActionServerLuaCall.java -> 
calls lua functions from the ability bin data.
There's a few more besides "FromGroup", but FromGroup is the easiest and most common.

GroupEventLuaContext.java ->
context.target_entity_id and context.source_entity_id happens from time to time. This makes that not die horribly.

BaseHandler.java ->
This actually shows you which specific function in ScriptLib needs implementation instead of just saying "ScriptLib!"

GameSession.java ->
BANNED_PACKETS was changed to be strings instead of numbers. If nothing else, we need this patched in ASAP so that the one person who still plays this branch doesn't get WindSeedClientNotify'd.


- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.