### PR TITLE
Make flowers (Dandelion, FlamingFlower, MistFlower) not interactable by default

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/GatherData.java
+++ b/src/main/java/emu/grasscutter/data/excels/GatherData.java
@@ -2,7 +2,9 @@ package emu.grasscutter.data.excels;
 
 import emu.grasscutter.data.GameResource;
 import emu.grasscutter.data.ResourceType;
+import lombok.Getter;
 
+@Getter
 @ResourceType(name = "GatherExcelConfigData.json")
 public class GatherData extends GameResource {
 	private int pointType;
@@ -12,34 +14,10 @@ public class GatherData extends GameResource {
 	private int cd; // Probably hours
 	private boolean isForbidGuest;
 	private boolean initDisableInteract;
-	    
+
 	@Override
 	public int getId() {
 		return this.pointType;
-	}
-
-	public int getGatherId() {
-		return id;
-	}
-
-	public int getGadgetId() {
-		return gadgetId;
-	}
-
-	public int getItemId() {
-		return itemId;
-	}
-
-	public int getCd() {
-		return cd;
-	}
-
-	public boolean isForbidGuest() {
-		return isForbidGuest;
-	}
-
-	public boolean initDisableInteract() {
-		return initDisableInteract;
 	}
 
 	@Override

--- a/src/main/java/emu/grasscutter/game/entity/EntityBaseGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityBaseGadget.java
@@ -73,11 +73,6 @@ public abstract class EntityBaseGadget extends GameEntity<CreateGadgetEntityConf
         this.arguments = gadgetCreateConfig.getArguments();
         this.owner = gadgetCreateConfig.getPlayerOwner();
 
-        GatherData gatherData = GameData.getGatherDataMap().get(gadgetCreateConfig.getPointType());
-        if(gatherData != null) {
-            this.interactEnabled = !gatherData.initDisableInteract();
-        }
-
         if(gadgetCreateConfig.getContent() == null) {
             this.content = buildContent(gadgetCreateConfig);
         } else {

--- a/src/main/java/emu/grasscutter/game/entity/EntityBaseGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityBaseGadget.java
@@ -1,8 +1,10 @@
 package emu.grasscutter.game.entity;
 
+import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.config.ConfigEntityGadget;
 import emu.grasscutter.data.binout.config.fields.ConfigAbilityData;
 import emu.grasscutter.data.excels.GadgetData;
+import emu.grasscutter.data.excels.GatherData;
 import emu.grasscutter.game.ability.AbilityManager;
 import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
 import emu.grasscutter.game.entity.gadget.content.GadgetContent;
@@ -70,6 +72,11 @@ public abstract class EntityBaseGadget extends GameEntity<CreateGadgetEntityConf
         this.interactId = gadgetCreateConfig.getInteractId();
         this.arguments = gadgetCreateConfig.getArguments();
         this.owner = gadgetCreateConfig.getPlayerOwner();
+
+        GatherData gatherData = GameData.getGatherDataMap().get(gadgetCreateConfig.getPointType());
+        if(gatherData != null) {
+            this.interactEnabled = !gatherData.initDisableInteract();
+        }
 
         if(gadgetCreateConfig.getContent() == null) {
             this.content = buildContent(gadgetCreateConfig);

--- a/src/main/java/emu/grasscutter/game/entity/create_config/CreateGadgetEntityConfig.java
+++ b/src/main/java/emu/grasscutter/game/entity/create_config/CreateGadgetEntityConfig.java
@@ -5,6 +5,7 @@ import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.AbilityModifier;
 import emu.grasscutter.data.binout.config.ConfigEntityGadget;
 import emu.grasscutter.data.excels.GadgetData;
+import emu.grasscutter.data.excels.GatherData;
 import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.entity.gadget.content.GadgetContent;
@@ -44,6 +45,7 @@ public class CreateGadgetEntityConfig extends CreateEntityConfig<CreateGadgetEnt
     private GameEntity<?> owner;
     private boolean isPersistent = false;
     private boolean enableInteract = true;
+    private boolean forbidGuest = false;
     private int draftId = 0;
     private Set<Integer> worktopOptions;
     private boolean worktopIsPersistent;
@@ -126,6 +128,17 @@ public class CreateGadgetEntityConfig extends CreateEntityConfig<CreateGadgetEnt
         initBaseData();
     }
 
+    public CreateGadgetEntityConfig(GameEntity<?> parent, GatherData gatherData){
+        super(parent);
+        this.gadgetId = gatherData.getGadgetId();
+        this.enableInteract = !gatherData.isInitDisableInteract();
+        this.forbidGuest = gatherData.isForbidGuest();
+        this.item = new GameItem(gatherData.getItemId(), 1);
+        this.pointType = gatherData.getPointType();
+
+        initBaseData();
+    }
+
     public CreateGadgetEntityConfig(AbilityModifier.AbilityModifierAction action, AbilityActionCreateGadget createGadgetInfo){
         super(action);
         this.gadgetId = action.gadgetID;
@@ -154,6 +167,9 @@ public class CreateGadgetEntityConfig extends CreateEntityConfig<CreateGadgetEnt
         this.gadgetId = spawnDataEntry.getGadgetId();
         if (spawnDataEntry.getGadgetState() > 0) {
             this.gadgetState = spawnDataEntry.getGadgetState();
+        }
+        if(spawnDataEntry.getGatherItemId()>0){
+            this.item = new GameItem(spawnDataEntry.getGatherItemId(), 1);
         }
         initBaseData();
     }

--- a/src/main/java/emu/grasscutter/game/entity/gadget/content/GadgetGatherObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/content/GadgetGatherObject.java
@@ -1,13 +1,10 @@
 package emu.grasscutter.game.entity.gadget.content;
 
-import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
-import emu.grasscutter.data.excels.GatherData;
 import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.EntityItem;
 import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
-import emu.grasscutter.game.entity.gadget.content.GadgetContent;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActionReason;
@@ -30,20 +27,8 @@ public class GadgetGatherObject extends GadgetContent {
         super(gadget);
 
         val config = gadget.getSpawnConfig();
-
-        // overwrites the default spawn handling
-        if (gadget.getSpawnEntry() != null) {
-            this.itemId = gadget.getSpawnEntry().getGatherItemId();
-            return;
-        }
-
-        GatherData gatherData = GameData.getGatherDataMap().get(config.getPointType());
-        if(gatherData != null) {
-            this.itemId = gatherData.getItemId();
-            this.isForbidGuest = gatherData.isForbidGuest();
-        } else {
-            Grasscutter.getLogger().error("invalid gather object: {}", config.getConfigId());
-        }
+        this.itemId = config.getItem().getItemId();
+        this.isForbidGuest = config.isForbidGuest();
     }
 
     public int getItemId() {

--- a/src/main/java/emu/grasscutter/game/entity/gadget/content/GadgetGatherPoint.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/content/GadgetGatherPoint.java
@@ -4,7 +4,6 @@ import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.excels.GatherData;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
-import emu.grasscutter.game.entity.gadget.content.GadgetContent;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActionReason;
@@ -25,13 +24,15 @@ public class GadgetGatherPoint extends GadgetContent {
         val originalConfig = getGadget().getSpawnConfig();
         this.gatherData = GameData.getGatherDataMap().get(originalConfig.getPointType());
 
+        if(gatherData == null) {
+            throw new IllegalArgumentException("Invalid gather object: " + originalConfig.getConfigId());
+        }
 
         val scene = gadget.getScene();
-        val createConfig = new CreateGadgetEntityConfig(gadget, gatherData.getGadgetId())
+        val createConfig = new CreateGadgetEntityConfig(gadget, gatherData)
             .setBornPos(originalConfig.getBornPos().clone())
             .setBornRot(originalConfig.getBornRot().clone())
-            .setGadgetState(originalConfig.getGadgetState())
-            .setPointType(originalConfig.getPointType());
+            .setGadgetState(originalConfig.getGadgetState());
         createConfig.setInitDataSource(gadget.getSpawnConfig().getInitDataSource());
 
         gatherObjectChild = new EntityGadget(scene, createConfig);


### PR DESCRIPTION
## Description

Some gadget is not interactable by default, it's defined in optional field `initDisableInteract` from `ExcelBinOutput/GatherExcelConfigData.json`

## Issues fixed by this PR

With this fix, Dandelion, Flaming Flowers and Mist Flowers can only be gathered after being hit by the right element.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My pull request is unique and no other pull requests have been opened for these changes
- [ ] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [ ] I am responsible for any copyright issues with my code if it occurs in the future.