### PR TITLE
Fix: `eventExecutor` should log error instead of sliently fail

### DIFF
--- a/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
+++ b/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
@@ -49,7 +49,13 @@ public final class AbilityManager extends BasePlayerManager {
     static {
         eventExecutor = new ThreadPoolExecutor(4, 4,
             60, TimeUnit.SECONDS, new LinkedBlockingDeque<>(1000),
-            FastThreadLocalThread::new, new ThreadPoolExecutor.AbortPolicy());
+            r -> {
+                Thread thread = new FastThreadLocalThread(r);
+                thread.setUncaughtExceptionHandler((t, e) ->
+                    Loggers.getAbilitySystem().error("Uncaught exception in ability handling", e)
+                );
+                return thread;
+            }, new ThreadPoolExecutor.AbortPolicy());
 
         registerHandlers();
     }
@@ -100,7 +106,7 @@ public final class AbilityManager extends BasePlayerManager {
             return;
         }
 
-        eventExecutor.submit(() -> {
+        eventExecutor.execute(() -> {
             if (!handler.execute(ability, action, abilityData, target)) {
                 logger.error("executeAction exec ability action failed {} at {}", action.type, ability);
             }
@@ -115,7 +121,7 @@ public final class AbilityManager extends BasePlayerManager {
             return;
         }
 
-        eventExecutor.submit(() -> {
+        eventExecutor.execute(() -> {
             if (!handler.execute(ability, mixinData, abilityData)) {
                 logger.error("executeMixin exec ability action failed {} at {}", mixinData.type, ability);
             }

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -23,10 +23,7 @@ import org.anime_game_servers.core.gi.enums.QuestState;
 
 import javax.annotation.Nonnull;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.Consumer;
 
 public class QuestManager extends BasePlayerManager {
@@ -41,7 +38,15 @@ public class QuestManager extends BasePlayerManager {
     static {
         eventExecutor = new ThreadPoolExecutor(4, 4,
             60, TimeUnit.SECONDS, new LinkedBlockingDeque<>(1000),
-            FastThreadLocalThread::new, new ThreadPoolExecutor.AbortPolicy());
+            r -> {
+                Thread thread = new FastThreadLocalThread(r);
+                thread.setUncaughtExceptionHandler((t, e) ->
+                    QuestSystem.getLogger().error("Uncaught exception in quest handling {}", t.getName(), e)
+                );
+                return thread;
+            },
+            new ThreadPoolExecutor.AbortPolicy()
+        );
     }
     /*
         On SetPlayerBornDataReq, the server sends FinishedParentQuestNotify, with this exact
@@ -350,10 +355,10 @@ public class QuestManager extends BasePlayerManager {
     }
 
     public void queueEvent(QuestContent condType, String paramStr, int... params) {
-        eventExecutor.submit(() -> triggerEvent(condType, paramStr, params));
+        eventExecutor.execute(() -> triggerEvent(condType, paramStr, params));
     }
     public void queueEvent(QuestCond condType, String paramStr, int... params) {
-        eventExecutor.submit(() -> triggerEvent(condType, paramStr, params));
+        eventExecutor.execute(() -> triggerEvent(condType, paramStr, params));
     }
 
     //QUEST_EXEC are handled directly by each subQuest

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -41,7 +41,7 @@ public class QuestManager extends BasePlayerManager {
             r -> {
                 Thread thread = new FastThreadLocalThread(r);
                 thread.setUncaughtExceptionHandler((t, e) ->
-                    QuestSystem.getLogger().error("Uncaught exception in quest handling {}", t.getName(), e)
+                    QuestSystem.getLogger().error("Uncaught exception in quest handling", e)
                 );
                 return thread;
             },

--- a/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
@@ -164,7 +164,7 @@ public class QuestSystem extends BaseGameSystem {
             return;
         }
 
-        QuestManager.eventExecutor.submit(() -> {
+        QuestManager.eventExecutor.execute(() -> {
             if (!handler.execute(quest, execParam, params)) {
                 getLogger().debug("exec trigger failed {} at {}", execParam.getType().getValue(), quest.getQuestData());
             }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -84,8 +84,14 @@ public class SceneScriptManager {
     public static final ExecutorService eventExecutor;
     static {
         eventExecutor = new ThreadPoolExecutor(4, 4,
-                60, TimeUnit.SECONDS, new LinkedBlockingDeque<>(10000),
-                FastThreadLocalThread::new, new ThreadPoolExecutor.AbortPolicy());
+            60, TimeUnit.SECONDS, new LinkedBlockingDeque<>(10000),
+            r -> {
+                Thread thread = new FastThreadLocalThread(r);
+                thread.setUncaughtExceptionHandler((t, e) ->
+                    Loggers.getScriptSystem().error("Uncaught exception in script handling", e)
+                );
+                return thread;
+            }, new ThreadPoolExecutor.AbortPolicy());
     }
     public SceneScriptManager(Scene scene) {
         this.scene = scene;
@@ -716,7 +722,7 @@ public class SceneScriptManager {
          * e.g. CallEvent -> set -> ScriptLib.xxx -> CallEvent -> set -> remove -> NPE -> (remove)
          * So we use thread pool to clean the stack to avoid this new issue.
          */
-        eventExecutor.submit(() -> this.realCallEvent(params));
+        eventExecutor.execute(() -> this.realCallEvent(params));
     }
 
     private void realCallEvent(@Nonnull ScriptArgs params) {


### PR DESCRIPTION
## Description

Currently, when a quest condition or event is triggered, if there's some uncaught exception, the server just ignore it without logging out any useful error message.

I stumbled upon it when I tried Kaeya domain (main quest 307). Trial character (Kaeya) is not added.
I noticed some of the packets were missing, so after debugging I found out that this was silently failed:
```java
QuestManager.eventExecutor.submit(() -> {
    if (!handler.execute(quest, execParam, params)) {
        getLogger().debug("exec trigger failed {} at {}", execParam.getType().getValue(), quest.getQuestData());
    }
});
```

With this fix, it will print out the error along with the stack trace, which is useful to know what went wrong. I also fix it for script and ability system.
(This error below is caused by missing `GrantReason` java class generated from `.proto` files)
```
2025-03-26T13:47:24Z <ERROR:emu.grasscutter.game.quest.QuestManager> Uncaught exception in quest handling Thread-39: Cannot invoke "java.lang.Integer.intValue()" because the return value of "org.anime_game_servers.multi_proto.gi.messages.general.avatar.GrantReason.encodeToByteArray(org.anime_game_servers.core.base.Version)" is null
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "org.anime_game_servers.multi_proto.gi.messages.general.avatar.GrantReason.encodeToByteArray(org.anime_game_servers.core.base.Version)" is null
	at emu.grasscutter.game.avatar.TrialAvatar.trialAvatarInfoProto(TrialAvatar.java:138)
	at emu.grasscutter.game.avatar.TrialAvatar.protoBuilder(TrialAvatar.java:153)
	at emu.grasscutter.game.avatar.Avatar.toProto(Avatar.java:882)
	at emu.grasscutter.server.packet.send.PacketAvatarAddNotify.<init>(PacketAvatarAddNotify.java:10)
	at emu.grasscutter.game.player.Player.addTrialAvatar(Player.java:882)
	at emu.grasscutter.game.player.Player.addTrialAvatarForQuest(Player.java:893)
	at emu.grasscutter.game.quest.exec.ExecGrantTrialAvatar.execute(ExecGrantTrialAvatar.java:15)
	at emu.grasscutter.game.quest.QuestSystem.lambda$triggerExec$0(QuestSystem.java:168)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.