### PR TITLE
null checks

### DIFF
--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -337,7 +337,9 @@ public class ResourceLoader {
             });
 
         GameData.getQuestDataMap().values().forEach(data -> Optional.ofNullable(data.getGuide())
-            .map(SubQuestData.Guide::getGuideScene).ifPresent(sceneId -> data.getFinishCond().stream()
+            .map(SubQuestData.Guide::getGuideScene).ifPresent(sceneId -> {
+                if (data.getFinishCond() == null) return;
+                data.getFinishCond().stream()
                 .filter(c -> c.getType() == QuestContent.QUEST_CONTENT_ENTER_DUNGEON)
                 .filter(c -> !tempEntriesMap.containsKey(c.getParam()[0])).forEach(cond -> {
                     val scenePointEntry = GameData.getScenePointEntryById(sceneId == 0 ? 3 : sceneId, cond.getParam()[1]);
@@ -349,7 +351,8 @@ public class ResourceLoader {
 
                     tempEntriesMap.putIfAbsent(cond.getParam()[0],
                         DungeonEntries.create(cond.getParam()[0], scenePointEntry.getPointData(), tempExitHolderMap));
-                })));
+                    });
+            }));
     }
 
     private static void cacheTalentLevelSets() {
@@ -579,8 +582,10 @@ public class ResourceLoader {
                     if(mainQuest.getTalks() != null) {
                         mainQuest.getTalks().forEach(talkData -> GameData.getQuestTalkMap().put(talkData.getId(), mainQuest.getId()));
                     }
-                    for(SubQuestData quest : mainQuest.getSubQuests()){
-                        addToCache(quest);
+                    if (mainQuest.getSubQuests() != null) {
+                        for (SubQuestData quest : mainQuest.getSubQuests()) {
+                            addToCache(quest);
+                        }
                     }
                 } catch (IOException e) {
 
@@ -702,7 +707,7 @@ public class ResourceLoader {
                 }
             });
 
-            logger.debug("Loaded {} {} entries.", GameData.getMonsterConfigData().size(), className);
+            logger.debug("Loaded {} {} entries.", targetMap.size(), className);
         } catch (IOException e) {
             logger.error("Failed to load {} folder.", className);
         }
@@ -719,7 +724,7 @@ public class ResourceLoader {
                 }
             });
 
-            logger.debug("Loaded {} {} entries.", GameData.getMonsterConfigData().size(), className);
+            logger.debug("Loaded {} {} entries.", targetMap.size(), className);
         } catch (IOException e) {
             logger.error("Failed to load {} folder.", className);
         }

--- a/src/main/java/emu/grasscutter/data/common/quest/MainQuestData.java
+++ b/src/main/java/emu/grasscutter/data/common/quest/MainQuestData.java
@@ -34,7 +34,7 @@ public class MainQuestData {
 
     private SubQuestData[] subQuests;
     private List<TalkData> talks;
-    private long[] preloadLuaList;
+    // private long[] preloadLuaList;
 
     public int getId() {
         return id;

--- a/src/main/java/emu/grasscutter/game/entity/EntityTeam.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityTeam.java
@@ -15,6 +15,7 @@ public class EntityTeam extends MetaGameEntity implements StringAbilityEntity {
 
     public EntityTeam(Player player) {
         super(player.getScene());
+        this.player = player;
         initAbilities();
         this.id = player.getWorld().getNextEntityId(EntityIdType.TEAM);
     }

--- a/src/main/java/emu/grasscutter/game/managers/blossom/BlossomSchedule.java
+++ b/src/main/java/emu/grasscutter/game/managers/blossom/BlossomSchedule.java
@@ -59,7 +59,7 @@ public class BlossomSchedule implements BaseBlossomROSData {
             .orElse(3);
         val scriptSystem = world.getHost().getServer().getScriptSystem();
         val scene = scriptSystem.getSceneMeta(sceneId);
-
+        if (scene == null) return null;
         val group = scene.getGroup(groupsData.getNewGroupId());
         if(group == null) {
             Grasscutter.getLogger().warn("[BlossomSchedule] Unable to find group {} in scene {}", groupsData.getNewGroupId(), sceneId);

--- a/src/main/java/emu/grasscutter/game/player/PlayerProgressManager.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgressManager.java
@@ -215,6 +215,7 @@ public class PlayerProgressManager extends BasePlayerDataManager {
     private void addStatueQuestsOnLogin() {
         // Get all currently existing subquests for the "unlock all statues" main quest.
         var statueMainQuest = GameData.getMainQuestDataMap().get(303);
+        if (statueMainQuest == null) return;
         var statueSubQuests = statueMainQuest.getSubQuests();
 
         // Add the main statue quest if it isn't active yet.

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -372,7 +372,7 @@ public class GameMainQuest {
     public void tryFailSubQuests(QuestContent condType, String paramStr, int... params) {
         try {
             List<GameQuest> subQuestsWithCond = getChildQuests().values().stream()
-                .filter(p -> p.getState() == QuestState.QUEST_STATE_UNFINISHED)
+                .filter(p -> p.getState() == QuestState.QUEST_STATE_UNFINISHED && p.getQuestData().getFailCond() != null)
                 .filter(p -> p.getQuestData().getFailCond().stream().anyMatch(q -> q.getType() == condType))
                 .toList();
             val questSystem = this.getOwner().getServer().getQuestSystem();
@@ -399,7 +399,7 @@ public class GameMainQuest {
         try {
             List<GameQuest> subQuestsWithCond = getChildQuests().values().stream()
                 //There are subQuests with no acceptCond, but can be finished (example: 35104)
-                .filter(p -> p.getState() == QuestState.QUEST_STATE_UNFINISHED && p.getQuestData().getAcceptCond() != null)
+                .filter(p -> p.getState() == QuestState.QUEST_STATE_UNFINISHED && p.getQuestData().getFinishCond() != null)
                 .filter(p -> p.getQuestData().getFinishCond().stream().anyMatch(q -> q.getType() == condType))
                 .toList();
             val questSystem = this.getOwner().getServer().getQuestSystem();

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -165,10 +165,6 @@ public class GameQuest {
         if (questData.getFailCond() != null && questData.getFailCond().size() != 0) {
             this.failProgressList = new int[questData.getFailCond().size()];
         }
-
-        this.getMainQuest().getTalks().values()
-            .removeIf(talk -> talk.getId() >= this.getSubQuestId());
-
         setState(QuestState.QUEST_STATE_UNSTARTED);
         finishTime = 0;
         acceptTime = 0;

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -109,8 +109,9 @@ public class GameQuest {
 
         //Some subQuests and talks become active when some other subQuests are unfinished (even from different MainQuests)
         triggerStateEvents();
-
-        getQuestData().getBeginExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(this, e, e.getParam()));
+        if (getQuestData().getBeginExec() != null) {
+            getQuestData().getBeginExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(this, e, e.getParam()));
+        }
         getOwner().getQuestManager().checkQuestAlreadyFulfilled(this, true);
         getOwner().getDungeonEntryManager().checkQuestForDungeonEntryUpdate(this);
         getOwner().getCoopHandler().checkNextCoopPointAccept(this.getSubQuestId());
@@ -164,6 +165,10 @@ public class GameQuest {
         if (questData.getFailCond() != null && questData.getFailCond().size() != 0) {
             this.failProgressList = new int[questData.getFailCond().size()];
         }
+
+        this.getMainQuest().getTalks().values()
+            .removeIf(talk -> talk.getId() >= this.getSubQuestId());
+
         setState(QuestState.QUEST_STATE_UNSTARTED);
         finishTime = 0;
         acceptTime = 0;
@@ -193,8 +198,8 @@ public class GameQuest {
             // This quest finishes the questline - the main quest will also save the quest to db, so we don't have to call save() here
             getMainQuest().finish(isManualFinish);
         }
-
-        getQuestData().getFinishExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(this, e, e.getParam()));
+        if (getQuestData().getFinishExec() != null)
+            getQuestData().getFinishExec().forEach(e -> getOwner().getServer().getQuestSystem().triggerExec(this, e, e.getParam()));
         //Some subQuests have conditions that subQuests are finished (even from different MainQuests)
         triggerStateEvents();
         getOwner().getScene().triggerDungeonEvent(DungeonPassConditionType.DUNGEON_COND_FINISH_QUEST, getSubQuestId());

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -121,6 +121,7 @@ public class QuestManager extends BasePlayerManager {
             //execute all the beginExec before the rewind target on UNFINISHED quests on login only
             quest.getChildQuests().values().stream().filter(p -> p.getQuestData().getOrder() < finalRewindTarget.getQuestData().getOrder()
                     && p.getState().getValue() == QuestState.QUEST_STATE_UNFINISHED.getValue()).forEach(q -> {
+                if (q.getQuestData().getBeginExec() == null) return;
                 q.getQuestData().getBeginExec().forEach(e -> getPlayer().getServer().getQuestSystem().triggerExec(q, e, e.getParam()));
             });
             quest.checkProgress(false);
@@ -426,7 +427,7 @@ public class QuestManager extends BasePlayerManager {
                 quest.finish(false);
                 return;
             }
-            if(!questData.getFailCond().isEmpty()) {
+            if (questData.getFailCond() != null && !questData.getFailCond().isEmpty()) {
                 val shouldFail = questSystem.initialCheckContent(quest, quest.getFailProgressList(), questData.getFailCond(), questData.getFailCondComb(), shouldReset);
                 if (shouldFail) {
                     quest.fail();

--- a/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestSystem.java
@@ -92,6 +92,7 @@ public class QuestSystem extends BaseGameSystem {
     }
 
     private BaseContent getContentHandler(QuestContent type, SubQuestData questData){
+        if (type == null) return contHandlers.get(QuestContent.QUEST_CONTENT_UNKNOWN.getValue());
         val handler = contHandlers.get(type.getValue());
         if(handler == null){
             getLogger().debug("Could not get handler for content {} in quest {}", type.getValue(), questData);

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentUnknown.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentUnknown.java
@@ -1,6 +1,5 @@
 package emu.grasscutter.game.quest.content;
 
-import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.common.quest.SubQuestData.QuestContentCondition;
 import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestSystem;
@@ -18,7 +17,8 @@ public class ContentUnknown extends BaseContent {
 
     @Override
     public boolean checkProgress(GameQuest quest, QuestContentCondition condition, int currentProgress) {
-        QuestSystem.getLogger().error("Unknown condition {} at {}", condition.getType().name(), quest.getSubQuestId());
+        if (condition.getType() != null)
+            QuestSystem.getLogger().error("Unknown condition {} at {}", condition.getType().name(), quest.getSubQuestId());
         return false;
     }
 }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -816,7 +816,7 @@ public class Scene {
         this.scriptManager.meetEntities(entities);
         this.scriptManager.addEntities(entitiesBorn);
         groups.forEach(g -> this.scriptManager.callEvent(new ScriptArgs(g.getGroupInfo().getId(), EventType.EVENT_GROUP_LOAD, g.getGroupInfo().getId())));
-        Grasscutter.getLogger().info("Scene {} loaded {} group(s)", getId(), groups.size());
+        Grasscutter.getLogger().info("Scene {} loaded {} group(s): {}", getId(), groups.size(), groups.stream().map(x -> x.getGroupInfo().getId()).toList());
     }
 
     /**


### PR DESCRIPTION
## Description

　　 ∧＿∧
　　（　´∀｀）＜ ぬるぽ

When trying 5.3, I was getting I lot of null pointer exceptions because the 5.3 questing resources are missing quite a few fields that grasscutter expects to be there, but blank.


Side bugs that are coming along for the ride:

ResourceLoader:
`GameData.getMonsterConfigData()` should be `targetMap` here in order for the print to give accurate data.

Scene:
When groups load, it's useful to know which groups loaded, not just how many.




## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.