### PR TITLE
[Feature] Proper activity group loading and activity currency handling

### DIFF
--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -10,6 +10,7 @@ import emu.grasscutter.data.common.quest.MainQuestData;
 import emu.grasscutter.data.common.quest.SubQuestData;
 import emu.grasscutter.data.custom.TrialAvatarActivityCustomData;
 import emu.grasscutter.data.custom.TrialAvatarCustomData;
+import emu.grasscutter.data.custom.activity.ActivityExtraInfo;
 import emu.grasscutter.data.excels.*;
 import emu.grasscutter.data.server.*;
 import emu.grasscutter.game.dungeons.DungeonDropEntry;
@@ -186,6 +187,7 @@ public class GameData {
     @Getter private static final Int2ObjectMap<ActivityCondGroup> activityCondGroupMap = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<SceneGroupReplacement> groupReplacements = new Int2ObjectOpenHashMap<>();
     @Getter private static final Int2ObjectMap<WeatherMapping> weatherMappingMap = new Int2ObjectOpenHashMap<>();
+    @Getter private static final Int2ObjectMap<ActivityExtraInfo> activityExtraMap = new Int2ObjectOpenHashMap<>();
 
     // Cache
     @Getter private static final IntList scenePointIdList = new IntArrayList();

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -15,6 +15,7 @@ import emu.grasscutter.data.common.quest.MainQuestData;
 import emu.grasscutter.data.common.quest.SubQuestData;
 import emu.grasscutter.data.custom.TrialAvatarActivityCustomData;
 import emu.grasscutter.data.custom.TrialAvatarCustomData;
+import emu.grasscutter.data.custom.activity.ActivityExtraInfo;
 import emu.grasscutter.data.excels.TrialAvatarActivityDataData;
 import emu.grasscutter.data.server.*;
 import emu.grasscutter.game.ability.Ability;
@@ -145,6 +146,7 @@ public class ResourceLoader {
         loadWeatherMappings();
         loadMonsterMappings();
         loadActivityCondGroups();
+        loadCustomActivityData();
         loadTrialAvatarCustomData();
         loadGlobalCombatConfig();
         EntityControllerScriptManager.load();
@@ -975,6 +977,18 @@ public class ResourceLoader {
             logger.debug("Loaded trial avatar custom data.");
         } catch (Exception e) {
             logger.error("Unable to load trial avatar custom data.", e);
+        }
+    }
+
+    private static void loadCustomActivityData() {
+        try {
+            val activityMap = GameData.getActivityExtraMap();
+            try {
+                JsonUtils.loadToList(getResourcePath("Server/ActivityExtraInfo.json"), ActivityExtraInfo.class).forEach(entry -> activityMap.put(entry.getActivityId(), entry));
+            } catch (IOException | NullPointerException ignored) {}
+            logger.debug("Loaded {} extra activity info.", activityMap.size());
+        } catch (Exception e) {
+            logger.error("Unable to load extra activity info.", e);
         }
     }
 

--- a/src/main/java/emu/grasscutter/data/custom/activity/ActivityExtraInfo.java
+++ b/src/main/java/emu/grasscutter/data/custom/activity/ActivityExtraInfo.java
@@ -1,0 +1,72 @@
+package emu.grasscutter.data.custom.activity;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+import lombok.Data;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Data
+public class ActivityExtraInfo {
+    private int activityId;
+    private int duration;
+    private int rewardPreview;
+    private int specialReward;
+    @Nullable private IntList defaultGroups = null;
+    @Nullable private IntList defaultWatchers = null;
+    @Nullable private List<ActivityStateCondition> startConditions = null;
+    @Nullable private List<ActivityStateCondition> activeConditions = null;
+
+
+    public boolean hasDuration() {
+        return duration > 0;
+    }
+    public boolean hasRewardPreview() {
+        return rewardPreview > 0;
+    }
+    public boolean hasSpecialReward() {
+        return specialReward > 0;
+    }
+    public boolean hasDefaultGroups() {
+        return defaultGroups != null && !defaultGroups.isEmpty();
+    }
+    public boolean hasDefaultWatchers() {
+        return defaultWatchers != null && !defaultWatchers.isEmpty();
+    }
+    public boolean hasStartConditions() {
+        return startConditions != null && !startConditions.isEmpty();
+    }
+    public boolean hasActiveConditions() {
+        return activeConditions != null && !activeConditions.isEmpty();
+    }
+
+
+    @Data
+    class ActivityStateCondition{
+        private ActivityStateCondType type;
+        private String param;
+    }
+
+    public enum ActivityStateCondType {
+        NONE,
+
+        /**
+         * Players requires a specific adventure rank
+         * param [0]: level the player needs to reach
+         */
+        PLAYER_LEVEL,
+
+        /**
+         * Players requires specific quests to be finished
+         * param: list of quest ids required, separated by commas
+         */
+        FINISH_QUESTS,
+
+        /**
+         * Players requires specific main/parent quests to be finished
+         * param: list of parent quest ids required, separated by commas
+         */
+        FINISH_MAIN_QUESTS,
+        UNKNOWN;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/activity/ActivityConfigItem.java
+++ b/src/main/java/emu/grasscutter/game/activity/ActivityConfigItem.java
@@ -19,7 +19,7 @@ public class ActivityConfigItem {
     Date closeTime;
     Date endTime;
 
-    transient ActivityHandler activityHandler;
+    transient ActivityHandler<?> activityHandler;
 
     void onLoad(){
         if(openTime == null){

--- a/src/main/java/emu/grasscutter/game/activity/ActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/ActivityHandler.java
@@ -8,6 +8,7 @@ import emu.grasscutter.game.activity.condition.ActivityConditionExecutor;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.WatcherTriggerType;
 import emu.grasscutter.game.quest.enums.QuestCond;
+import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.utils.DateHelper;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public abstract class ActivityHandler {
+public abstract class ActivityHandler<PLAYER_DETAIL_DATA> {
     /**
      * Must set before initWatchers
      */
@@ -30,8 +31,22 @@ public abstract class ActivityHandler {
     @Getter ActivityData activityData;
     Map<WatcherTriggerType, List<ActivityWatcher>> watchersMap = new HashMap<>();
 
-    abstract public void onProtoBuild(PlayerActivityData playerActivityData, ActivityInfo activityInfo);
-    abstract public void onInitPlayerActivityData(PlayerActivityData playerActivityData);
+    public abstract void onProtoBuild(PlayerActivityData playerActivityData, ActivityInfo activityInfo);
+    public abstract PLAYER_DETAIL_DATA onInitPlayerActivityData(PlayerActivityData playerActivityData);
+
+    public void onLoadScene(Scene scene, Player player, ActivityConfigItem activityInfo) {
+        if(scene.getId() != 3){
+            return;
+        }
+        val activityId = activityInfo.getActivityId();
+
+        val activityExtraInfo = GameData.getActivityExtraMap().get(activityId);
+        if(activityExtraInfo == null || !activityExtraInfo.hasDefaultGroups()){
+            return;
+        }
+
+        activityExtraInfo.getDefaultGroups().forEach(scene::loadDynamicGroup);
+    }
 
     public void initWatchers(Map<WatcherTriggerType, ConstructorAccess<?>> activityWatcherTypeMap){
         activityData = GameData.getActivityDataMap().get(activityConfigItem.getActivityId());
@@ -53,6 +68,8 @@ public abstract class ActivityHandler {
             watchersMap.get(watcherData.getTriggerConfig().getWatcherTriggerType()).add(watcher);
         });
     }
+
+    public void initCurrencyHandlers(PlayerActivityData playerActivityData){}
 
     protected void triggerCondEvents(Player player){
         if(activityData == null){

--- a/src/main/java/emu/grasscutter/game/activity/ActivityManager.java
+++ b/src/main/java/emu/grasscutter/game/activity/ActivityManager.java
@@ -9,6 +9,7 @@ import emu.grasscutter.game.player.BasePlayerManager;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActivityType;
 import emu.grasscutter.game.props.WatcherTriggerType;
+import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.server.packet.send.PacketActivityScheduleInfoNotify;
 import lombok.Getter;
 import lombok.val;
@@ -86,12 +87,14 @@ public class ActivityManager extends BasePlayerManager {
         // load data for player
         activityConfigItemMap.values().forEach(item -> {
             var data = PlayerActivityData.getByPlayer(player, item.getActivityId());
+            val activityHandler = item.getActivityHandler();
             if (data == null) {
-                data = item.getActivityHandler().initPlayerActivityData(player);
+                data = activityHandler.initPlayerActivityData(player);
                 data.save();
             }
             data.setPlayer(player);
-            data.setActivityHandler(item.getActivityHandler());
+            data.setActivityHandler(activityHandler);
+            activityHandler.initCurrencyHandlers(data);
             playerActivityDataMap.put(item.getActivityId(), data);
         });
 
@@ -181,7 +184,7 @@ public class ActivityManager extends BasePlayerManager {
         return activityHandler.toProto(activityData, conditionExecutor);
     }
 
-    public Optional<ActivityHandler> getActivityHandler(ActivityType type) {
+    public Optional<? extends ActivityHandler<?>> getActivityHandler(ActivityType type) {
         return activityConfigItemMap.values().stream()
             .map(ActivityConfigItem::getActivityHandler)
             .filter(x -> type == x.getClass().getAnnotation(GameActivity.class).value())
@@ -211,6 +214,14 @@ public class ActivityManager extends BasePlayerManager {
             .filter(x -> isActivityActive(x.getActivityId()))
             .map(ActivityConfigItem::getActivityId)
             .toList();
+    }
+
+    public void triggerSceneLoadForActiveActivity(Scene scene){
+        getActiveActivityIds().forEach(activityId -> {
+            val activityConfig = activityConfigItemMap.get(activityId);
+            val activityHandler = activityConfig.getActivityHandler();
+            activityHandler.onLoadScene(scene, player, activityConfig);
+        });
     }
 
 }

--- a/src/main/java/emu/grasscutter/game/activity/DefaultActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/DefaultActivityHandler.java
@@ -4,14 +4,14 @@ import emu.grasscutter.game.props.ActivityType;
 import org.anime_game_servers.multi_proto.gi.messages.activity.general.ActivityInfo;
 
 @GameActivity(ActivityType.NONE)
-public class DefaultActivityHandler extends ActivityHandler{
+public class DefaultActivityHandler extends ActivityHandler<Object>{
     @Override
     public void onProtoBuild(PlayerActivityData playerActivityData, ActivityInfo activityInfo) {
 
     }
 
     @Override
-    public void onInitPlayerActivityData(PlayerActivityData playerActivityData) {
-
+    public Object onInitPlayerActivityData(PlayerActivityData playerActivityData) {
+        return null;
     }
 }

--- a/src/main/java/emu/grasscutter/game/activity/PlayerActivityData.java
+++ b/src/main/java/emu/grasscutter/game/activity/PlayerActivityData.java
@@ -16,6 +16,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.anime_game_servers.multi_proto.gi.messages.activity.general.ActivityWatcherInfo;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +95,14 @@ public class PlayerActivityData {
         player.getInventory().addItems(rewards, ActionReason.ActivityWatcher);
         watcher.setTakenReward(true);
         save();
+    }
+
+    @Nullable
+    public <T> T getDetail(Class<T> clazz) {
+        if (detail == null || detail.isBlank()) {
+            return null;
+        }
+        return JsonUtils.decode(detail, clazz);
     }
 
     @Entity

--- a/src/main/java/emu/grasscutter/game/activity/aster/AsterActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/aster/AsterActivityHandler.java
@@ -3,6 +3,7 @@ package emu.grasscutter.game.activity.aster;
 import emu.grasscutter.game.activity.ActivityHandler;
 import emu.grasscutter.game.activity.GameActivity;
 import emu.grasscutter.game.activity.PlayerActivityData;
+import emu.grasscutter.game.inventory.Inventory;
 import emu.grasscutter.game.props.ActivityType;
 import emu.grasscutter.server.packet.send.*;
 import lombok.val;
@@ -14,22 +15,37 @@ import java.util.List;
 import java.util.Map;
 
 @GameActivity(ActivityType.NEW_ACTIVITY_ASTER)
-public class AsterActivityHandler extends ActivityHandler {
+public class AsterActivityHandler extends ActivityHandler<AsterGamePlayerData> implements Inventory.VirtualCurrencyHandler<PlayerActivityData> {
 
     @Override
-    public void onInitPlayerActivityData(PlayerActivityData playerActivityData) {
-        /*var musicGamePlayerData = MusicGamePlayerData.create();
+    public AsterGamePlayerData onInitPlayerActivityData(PlayerActivityData playerActivityData) {
+        var activityDetailData = AsterGamePlayerData.create();
+        playerActivityData.setDetail(activityDetailData);
+        return activityDetailData;
+    }
 
-        playerActivityData.setDetail(musicGamePlayerData);*/
+    @Override
+    public void initCurrencyHandlers(PlayerActivityData playerActivityData) {
+        super.initCurrencyHandlers(playerActivityData);
+        val inventory = playerActivityData.getPlayer().getInventory();
+        inventory.registerVirtualCurrencyHandler(109, this, playerActivityData); // Aster Credit
+        inventory.registerVirtualCurrencyHandler(110, this, playerActivityData); // Aster Token
     }
 
     @Override
     public void onProtoBuild(PlayerActivityData playerActivityData, ActivityInfo activityInfo) {
+        var asterDetail = playerActivityData.getDetail(AsterGamePlayerData.class);
+        if(asterDetail == null) {
+            asterDetail = onInitPlayerActivityData(playerActivityData);
+            playerActivityData.save();
+        }
+
         val asterLittle = new AsterLittleDetailInfo();
         asterLittle.setOpen(true);
         asterLittle.setBeginTime(activityInfo.getFirstDayStartTime());
         asterLittle.setStageBeginTime(activityInfo.getFirstDayStartTime());
-        asterLittle.setStageId(1);
+        // todo get stage based on AsterStageExcelConfigData and the day
+        asterLittle.setStageId(3);
         asterLittle.setStageState(AsterLittleStageState.ASTER_LITTLE_STAGE_STARTED);
 
         playerActivityData.getPlayer().sendPacket(new PacketAsterLittleInfoNotify(asterLittle));
@@ -51,21 +67,80 @@ public class AsterActivityHandler extends ActivityHandler {
         playerActivityData.getPlayer().sendPacket(new PacketAsterLargeInfoNotify(asterLarge));
 
         val asterProgressDetailInfo = new AsterProgressDetailInfo();
-        asterProgressDetailInfo.setCount(1);
+        asterProgressDetailInfo.setCount(1000);
         asterProgressDetailInfo.setLastAutoAddTime(activityInfo.getFirstDayStartTime());
         playerActivityData.getPlayer().sendPacket(new PacketAsterProgressInfoNotify(asterProgressDetailInfo));
 
         val asterInfo = new AsterActivityDetailInfo(asterLittle, asterMiddle, asterLarge, asterProgressDetailInfo);
         asterInfo.setContentClosed(false);
         asterInfo.setContentCloseTime(asterInfo.getContentCloseTime());
-        asterInfo.setSpecialRewardTaken(false);
-        asterInfo.setAsterToken(50); //109
-        asterInfo.setAsterCredit(60); //110
-        playerActivityData.getPlayer().sendPacket(new PacketAsterMiscInfoNotify(50, 60));
+        asterInfo.setSpecialRewardTaken(asterInfo.isSpecialRewardTaken());
+
+
+        // Aster specific currencies
+        val tokenCount = asterDetail.getAsterToken();
+        val creditCount = asterDetail.getAsterCredit();
+        asterInfo.setAsterToken(tokenCount);
+        asterInfo.setAsterCredit(creditCount);
+        playerActivityData.getPlayer().sendPacket(new PacketAsterMiscInfoNotify(creditCount, tokenCount));
 
         activityInfo.setDetail(new ActivityInfo.Detail.AsterInfo(asterInfo));
         activityInfo.setActivityCoinMap(Map.of(109, 1, 110, 1));
     }
 
+    @Override
+    public int getCurrency(PlayerActivityData playerActivityData, int itemId) {
+        val playerData = playerActivityData.getDetail(AsterGamePlayerData.class);
+        if (playerData == null) {
+            return 0;
+        }
+        if(itemId == 109) {
+            return playerData.getAsterCredit();
+        } else if(itemId == 110) {
+            return playerData.getAsterToken();
+        }
+        return 0;
+    }
 
+    @Override
+    public void setCurrency(PlayerActivityData playerActivityData, int itemId, int count) {
+        var detail = playerActivityData.getDetail(AsterGamePlayerData.class);
+        if(detail == null) {
+            detail = onInitPlayerActivityData(playerActivityData);
+            playerActivityData.save();
+        }
+
+        if (itemId == 109) {
+            detail.setAsterCredit(count);
+        } else if(itemId == 110) {
+            detail.setAsterToken(count);
+        }
+        playerActivityData.setDetail(detail);
+        playerActivityData.save();
+        playerActivityData.getPlayer().sendPacket(
+            new PacketAsterMiscInfoNotify(detail.getAsterCredit(), detail.getAsterToken())
+        );
+    }
+
+    @Override
+    public void modifyCurrency(PlayerActivityData playerActivityData, int itemId, int modifyValue) {
+        var detail = playerActivityData.getDetail(AsterGamePlayerData.class);
+        if(detail == null) {
+            detail = onInitPlayerActivityData(playerActivityData);
+            playerActivityData.save();
+        }
+
+        var asterToken = detail.getAsterToken();
+        var asterCredit = detail.getAsterCredit();
+        if (itemId == 109) {
+            detail.setAsterCredit(asterCredit+modifyValue);
+        } else if(itemId == 110) {
+            detail.setAsterToken(asterToken+modifyValue);
+        }
+        playerActivityData.setDetail(detail);
+        playerActivityData.save();
+        playerActivityData.getPlayer().sendPacket(
+            new PacketAsterMiscInfoNotify(detail.getAsterCredit(), detail.getAsterToken())
+        );
+    }
 }

--- a/src/main/java/emu/grasscutter/game/activity/aster/AsterGamePlayerData.java
+++ b/src/main/java/emu/grasscutter/game/activity/aster/AsterGamePlayerData.java
@@ -1,0 +1,22 @@
+package emu.grasscutter.game.activity.aster;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "of")
+public class AsterGamePlayerData {
+    int asterToken;
+    int asterCredit;
+    boolean specialRewardTaken = false;
+
+    public static AsterGamePlayerData create() {
+        return AsterGamePlayerData.of()
+            .build();
+    }
+}
+
+

--- a/src/main/java/emu/grasscutter/game/activity/irodori/IrodoriActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/irodori/IrodoriActivityHandler.java
@@ -1,21 +1,19 @@
 package emu.grasscutter.game.activity.irodori;
 
-import emu.grasscutter.game.activity.ActivityConfigItem;
 import emu.grasscutter.game.activity.ActivityHandler;
 import emu.grasscutter.game.activity.GameActivity;
 import emu.grasscutter.game.activity.PlayerActivityData;
-import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActivityType;
-import emu.grasscutter.game.world.Scene;
 import lombok.val;
 import org.anime_game_servers.multi_proto.gi.messages.activity.general.ActivityInfo;
 import org.anime_game_servers.multi_proto.gi.messages.activity.irodori_chess.IrodoriActivityDetailInfo;
 
 @GameActivity(ActivityType.NEW_ACTIVITY_IRODORI)
-public class IrodoriActivityHandler extends ActivityHandler {
+public class IrodoriActivityHandler extends ActivityHandler<Object> {
 
     @Override
-    public void onInitPlayerActivityData(PlayerActivityData playerActivityData) {
+    public Object onInitPlayerActivityData(PlayerActivityData playerActivityData) {
+        return null;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/activity/musicgame/MusicGameActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/musicgame/MusicGameActivityHandler.java
@@ -13,13 +13,14 @@ import org.anime_game_servers.multi_proto.gi.messages.activity.user_generated_co
 import java.util.stream.Collectors;
 
 @GameActivity(ActivityType.NEW_ACTIVITY_MUSIC_GAME)
-public class MusicGameActivityHandler extends ActivityHandler {
+public class MusicGameActivityHandler extends ActivityHandler<MusicGamePlayerData> {
 
     @Override
-    public void onInitPlayerActivityData(PlayerActivityData playerActivityData) {
+    public MusicGamePlayerData onInitPlayerActivityData(PlayerActivityData playerActivityData) {
         var musicGamePlayerData = MusicGamePlayerData.create();
 
         playerActivityData.setDetail(musicGamePlayerData);
+        return musicGamePlayerData;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/activity/trialavatar/TrialAvatarActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/trialavatar/TrialAvatarActivityHandler.java
@@ -24,14 +24,16 @@ import lombok.*;
 import org.anime_game_servers.multi_proto.gi.messages.activity.general.ActivityInfo;
 
 @GameActivity(ActivityType.NEW_ACTIVITY_TRIAL_AVATAR)
-public class TrialAvatarActivityHandler extends ActivityHandler {
+public class TrialAvatarActivityHandler extends ActivityHandler<TrialAvatarPlayerData> {
     @Getter private int selectedTrialAvatarIndex;
     private static final WatcherTriggerType triggerType = WatcherTriggerType.TRIGGER_FINISH_CHALLENGE;
     private static final TrialAvatarDungeonSettleListener TRIAL_AVATAR_DUNGEON_SETTLE_LISTENER = new TrialAvatarDungeonSettleListener();
 
     @Override
-    public void onInitPlayerActivityData(@NonNull PlayerActivityData playerActivityData) {
-        playerActivityData.setDetail(TrialAvatarPlayerData.create(getActivityConfigItem().getScheduleId()));
+    public TrialAvatarPlayerData onInitPlayerActivityData(@NonNull PlayerActivityData playerActivityData) {
+        val detailData = TrialAvatarPlayerData.create(getActivityConfigItem().getScheduleId());
+        playerActivityData.setDetail(detailData);
+        return detailData;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -34,6 +34,7 @@ import static emu.grasscutter.config.Configuration.INVENTORY_LIMITS;
 public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
     private final Long2ObjectMap<GameItem> store;
     private final Int2ObjectMap<InventoryTab> inventoryTypes;
+    private final Int2ObjectMap<VirtualCurrencyHandlerEntry> virtualCurrencyHandlers = new Int2ObjectOpenHashMap<>();
 
     public Inventory(Player player) {
         super(player);
@@ -362,6 +363,11 @@ public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
                 this.player.setCrystals(this.player.getCrystals() + count);
             case 204 -> // Home Coin
                 this.player.setHomeCoin(this.player.getHomeCoin() + count);
+            default -> {
+                if (virtualCurrencyHandlers.containsKey(itemId)) {
+                    virtualCurrencyHandlers.get(itemId).modifyCurrency(count);
+                }
+            }
         }
     }
 
@@ -380,6 +386,10 @@ public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
             case 204 ->  // Home Coin
                 player.setHomeCoin(player.getHomeCoin() - count);
             default -> {
+                if (virtualCurrencyHandlers.containsKey(itemId)) {
+                    virtualCurrencyHandlers.get(itemId).modifyCurrency(-count);
+                    return null;
+                }
                 var gameItem = getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(itemId);
                 removeItem(gameItem, count);
                 return gameItem;
@@ -403,8 +413,12 @@ public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
             case 204:  // Home Coin
                 return this.player.getHomeCoin();
             default:
-                GameItem item = getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(itemId);  // What if we ever want to operate on weapons/relics/furniture? :S
-                return (item == null) ? 0 : item.getCount();
+                if (virtualCurrencyHandlers.containsKey(itemId)) {
+                    return virtualCurrencyHandlers.get(itemId).getCurrency();
+                } else {
+                    GameItem item = getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(itemId);  // What if we ever want to operate on weapons/relics/furniture? :S
+                    return (item == null) ? 0 : item.getCount();
+                }
         }
     }
 
@@ -619,5 +633,43 @@ public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
 
     public Stream<GameItem> stream() {
         return this.getItems().values().stream();
+    }
+
+    public <T> void registerVirtualCurrencyHandler(int itemId, VirtualCurrencyHandler<T> handler, @Nullable T extraData) {
+        this.virtualCurrencyHandlers.put(itemId, new VirtualCurrencyHandlerEntry<>(itemId, handler, extraData));
+    }
+
+    public void unregisterVirtualCurrencyHandler(int itemId) {
+        this.virtualCurrencyHandlers.remove(itemId);
+    }
+
+    private static class VirtualCurrencyHandlerEntry<T>{
+        private final int itemId;
+        private final VirtualCurrencyHandler<T> handler;
+        private final T extraData;
+
+        public VirtualCurrencyHandlerEntry(int itemId, VirtualCurrencyHandler<T> handler, T extraData) {
+            this.itemId = itemId;
+            this.handler = handler;
+            this.extraData = extraData;
+        }
+
+        public int getCurrency() {
+            return handler.getCurrency(extraData, itemId);
+        }
+
+        public void setCurrency(int count) {
+            handler.setCurrency(extraData, itemId, count);
+        }
+
+        public void modifyCurrency(int count) {
+            handler.modifyCurrency(extraData, itemId, count);
+        }
+    }
+
+    public interface VirtualCurrencyHandler<T>{
+        int getCurrency(T extraData, int itemId);
+        void setCurrency(T extraData, int itemId, int count);
+        void modifyCurrency(T extraData, int itemId, int count);
     }
 }

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1361,6 +1361,9 @@ public class Player {
     }
 
     public void onLogin() {
+        // Activity needed for some quests
+        activityManager = new ActivityManager(this);
+
         // Create world
         World world = new World(this);
         world.addPlayer(this);
@@ -1376,9 +1379,6 @@ public class Player {
         if (this.levelTags.isEmpty()) {
             this.initializeLevelTags();
         }
-
-        // Activity needed for some quests
-        activityManager = new ActivityManager(this);
 
         // Rewind active quests, and put the player to a rewind position it finds (if any) of an active quest
         getQuestManager().onLogin();

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -366,7 +366,8 @@ public class QuestManager extends BasePlayerManager {
 
     public void triggerEvent(QuestCond condType, String paramStr, int... params) {
         QuestSystem.getLogger().debug("Trigger Event {}, {}, {}", condType, paramStr, params);
-        val potentialQuests = GameData.getQuestDataByConditions(condType, params[0], paramStr);
+        val param = params.length > 0 ? params[0] : 0;
+        val potentialQuests = GameData.getQuestDataByConditions(condType, param, paramStr);
         if(potentialQuests == null){
             return;
         }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -117,6 +117,7 @@ public class Scene {
         this.startWorldTime = world.getWorldTime();
 
         this.scriptManager = new SceneScriptManager(this);
+        getWorld().getHost().getActivityManager().triggerSceneLoadForActiveActivity(this);
 
         //Create scene entity
         this.sceneEntity = new EntityScene(this);

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -434,7 +434,10 @@ public class SceneScriptManager {
             return;
         }
         this.meta = meta;
-        meta.loadActivity(ScriptSystem.getScriptLoader(), 2001);
+        val activeActivities = this.getScene().getWorld().getHost().getActivityManager().getActiveActivityIds();
+        activeActivities.forEach(activityId -> {
+            meta.loadActivity(ScriptSystem.getScriptLoader(), activityId);
+        });
 
         // TEMP
         this.isInit = true;

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerMusicGameStartReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerMusicGameStartReq.java
@@ -9,7 +9,7 @@ public class HandlerMusicGameStartReq extends TypedPacketHandler<MusicGameStartR
 
 	@Override
 	public void handle(GameSession session, byte[] header, MusicGameStartReq req) throws Exception {
-		session.send(new PacketMusicGameStartRsp(req.getMusicBasicId(), req.getMusicBasicId()));
+		session.send(new PacketMusicGameStartRsp(req.getMusicBasicId(), req.getUgcGuid()));
 	}
 
 }


### PR DESCRIPTION
* Load "Server/ActivityExtraInfo.json" from the resources to get default dynamic groups to load
  * This should help with getting some of the 1.x activities working
* Load all activity Activity Groups in scene Manager
* Fix wrong second parameter for the MusicGameStartReq
* Added the ability to register to the Inventory as VirtualCurrencyHandler
  * This allows Activity Handlers like AsterActivityHandler to register for handling like aster credit and tokens