### PR TITLE
[Feature] QUEST EXEC SET IS FLYABLE

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -16,7 +16,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_LOCK_FORCE (5),                              //#Missing #Unused
     QUEST_EXEC_CHANGE_AVATAR_ELEMET (6),
     QUEST_EXEC_REFRESH_GROUP_MONSTER (7),
-    QUEST_EXEC_SET_IS_FLYABLE (8),                          //#Missing #Gives the glider
+    QUEST_EXEC_SET_IS_FLYABLE (8),
     QUEST_EXEC_SET_IS_WEATHER_LOCKED (9),
     QUEST_EXEC_SET_IS_GAME_TIME_LOCKED (10),
     QUEST_EXEC_SET_IS_TRANSFERABLE (11),                    //#Missing #Unused
@@ -74,7 +74,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_CHANGE_SCENE_LEVEL_TAG (64),
     QUEST_EXEC_UNLOCK_PLAYER_WORLD_SCENE (65),
     QUEST_EXEC_LOCK_PLAYER_WORLD_SCENE (66),                //#Missing
-    QUEST_EXEC_FAIL_MAINCOOP (67),                          //#Missing
+    QUEST_EXEC_FAIL_MAINCOOP (67),                          //#Missing #Unused
     QUEST_EXEC_MODIFY_WEATHER_AREA (68),
     QUEST_EXEC_MODIFY_ARANARA_COLLECTION_STATE (69),        //#Missing
     QUEST_EXEC_GRANT_TRIAL_AVATAR_BATCH_AND_LOCK_TEAM (70), //#Missing

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecSetIsFlyable.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecSetIsFlyable.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.common.quest.SubQuestData.QuestExecParam;
+import emu.grasscutter.game.props.PlayerProperty;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_SET_IS_FLYABLE)
+public class ExecSetIsFlyable extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
+        var canFly = Integer.parseInt(paramStr[0]);
+        quest.getOwner().setProperty(PlayerProperty.PROP_IS_FLYABLE, canFly);
+        return true;
+    }
+}


### PR DESCRIPTION
## Description

If you don't start with the glider unlocked, you get softlocked at this point in the prologue:
![image](https://github.com/user-attachments/assets/5eb7a0b6-43c0-4981-bb49-e82bf8ae3dee)

This PR adds the exec that gives you the glider on this quest.

## Issues fixed by this PR
if you didn't have the glider, this gives you the glider on the quest that gives you the glider.


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.