### PR TITLE
[Feature] QUEST EXEC REFRESH GROUP SUITE RANDOM

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -35,7 +35,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_NOTIFY_DAILY_TASK (24),                      //#Missing
     QUEST_EXEC_CREATE_PATTERN_GROUP (25),                   //#Missing #RandomQuestExcel
     QUEST_EXEC_REMOVE_PATTERN_GROUP (26),                   //#Missing #RandomQuestExcel
-    QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM (27),             //#Missing
+    QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM (27),
     QUEST_EXEC_ACTIVE_ITEM_GIVING (28),
     QUEST_EXEC_DEL_ALL_SPECIFIC_PACK_ITEM (29),             //#Missing
     QUEST_EXEC_ROLLBACK_PARENT_QUEST (30),

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecRefreshGroupSuiteRandom.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecRefreshGroupSuiteRandom.java
@@ -7,7 +7,7 @@ import emu.grasscutter.game.quest.enums.QuestExec;
 import emu.grasscutter.game.quest.handlers.QuestExecHandler;
 import lombok.val;
 
-import java.util.Random;
+import static emu.grasscutter.utils.Utils.random;
 
 @QuestValueExec(QuestExec.QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM)
 public class ExecRefreshGroupSuiteRandom extends QuestExecHandler {
@@ -22,7 +22,7 @@ public class ExecRefreshGroupSuiteRandom extends QuestExecHandler {
         for (var entry : entries) {
             val entryArray = entry.split(",");
             val groupId = Integer.parseInt(entryArray[0]);
-            val randomSuiteIndex = new Random().nextInt(1, entryArray.length);
+            val randomSuiteIndex = random.nextInt(1, entryArray.length);
             val suiteId = Integer.parseInt(entryArray[randomSuiteIndex]);
 
             if (!scriptManager.refreshGroupSuite(groupId, suiteId, quest)) {

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecRefreshGroupSuiteRandom.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecRefreshGroupSuiteRandom.java
@@ -1,0 +1,36 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.common.quest.SubQuestData.QuestExecParam;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import lombok.val;
+
+import java.util.Random;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM)
+public class ExecRefreshGroupSuiteRandom extends QuestExecHandler {
+
+    @Override
+    public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
+        val sceneId = Integer.parseInt(paramStr[0]);
+        val entries = paramStr[1].split(";");
+        val scriptManager = quest.getOwner().getWorld().getSceneById(sceneId).getScriptManager();
+
+        boolean result = true;
+        for (var entry : entries) {
+            val entryArray = entry.split(",");
+            val groupId = Integer.parseInt(entryArray[0]);
+            val randomSuiteIndex = new Random().nextInt(1, entryArray.length);
+            val suiteId = Integer.parseInt(entryArray[randomSuiteIndex]);
+
+            if (!scriptManager.refreshGroupSuite(groupId, suiteId, quest)) {
+                result = false;
+            }
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
## Description
In quest 2001903, the monsters are not spawning:
![image](https://github.com/user-attachments/assets/0d2f1cb0-48e7-48d4-8b6f-756d991e8471)

This is a QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM.

setting it to load any one of the suites it specifies results in monsters, torches, crates, and gadgets:
![image](https://github.com/user-attachments/assets/677f6ab8-94cc-4ef7-aa76-534a00bb9027)

## Issues fixed by this PR
This allows suites specified by QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM to be loaded. This is only done in dailies.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.