### PR TITLE
[Feature] QUEST EXEC DEL ALL SPECIFIC PACK ITEM

### DIFF
--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -478,24 +478,26 @@ public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
     }
 
     public void removeItems(List<GameItem> items) {
-        // TODO Bulk delete
-        for (GameItem item : items) {
-            this.removeItem(item, item.getCount());
-        }
+        items.forEach(this::removeItem);
     }
 
     public boolean removeItem(long guid) {
-        return removeItem(guid, 1);
+        return removeItem(this.getItemByGuid(guid));
     }
 
     public synchronized boolean removeItem(long guid, int count) {
-        GameItem item = this.getItemByGuid(guid);
+        return removeItem(this.getItemByGuid(guid), count);
+    }
 
-        if (item == null) {
-            return false;
-        }
-
-        return removeItem(item, count);
+    /**
+     * Removes every amount of an item by its item ID.
+     *
+     * @param itemId The ID of the item to remove.
+     * @return True if the item was removed, false otherwise.
+     */
+    public synchronized boolean removeItemById(int itemId) {
+        var item = this.getItems().values().stream().filter(i -> i.getItemId() == itemId).findFirst();
+        return item.filter(this::removeItem).isPresent();
     }
 
     /**

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -37,7 +37,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_REMOVE_PATTERN_GROUP (26),                   //#Missing #RandomQuestExcel
     QUEST_EXEC_REFRESH_GROUP_SUITE_RANDOM (27),
     QUEST_EXEC_ACTIVE_ITEM_GIVING (28),
-    QUEST_EXEC_DEL_ALL_SPECIFIC_PACK_ITEM (29),             //#Missing
+    QUEST_EXEC_DEL_ALL_SPECIFIC_PACK_ITEM (29),
     QUEST_EXEC_ROLLBACK_PARENT_QUEST (30),
     QUEST_EXEC_LOCK_AVATAR_TEAM (31),                       //#Missing
     QUEST_EXEC_UNLOCK_AVATAR_TEAM (32),                     //#Missing

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecDelAllSpecificPackItem.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecDelAllSpecificPackItem.java
@@ -1,0 +1,24 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.common.quest.SubQuestData.QuestExecParam;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import lombok.val;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_DEL_ALL_SPECIFIC_PACK_ITEM)
+public class ExecDelAllSpecificPackItem extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
+        val items = paramStr[0].split(",");
+        boolean success = true;
+        for (var itemIdString : items) {
+            val itemId = Integer.parseInt(itemIdString);
+            if (!quest.getOwner().getInventory().removeItemById(itemId)) {
+                success = false;
+            }
+        }
+        return success;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecDelPackItem.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecDelPackItem.java
@@ -12,6 +12,6 @@ public class ExecDelPackItem extends QuestExecHandler {
     public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
         int itemId = Integer.parseInt(paramStr[0]);
         int amount = Integer.parseInt(paramStr[1]);
-        return quest.getOwner().getInventory().removeItem(itemId, amount);
+        return quest.getOwner().getInventory().removeItemById(itemId, amount);
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecDelPackItemBatch.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecDelPackItemBatch.java
@@ -17,7 +17,7 @@ public class ExecDelPackItemBatch extends QuestExecHandler {
             var itemFields = itemString.split(":");
             var itemId = Integer.parseInt(itemFields[0]);
             var amount = Integer.parseInt(itemFields[1]);
-            if(!quest.getOwner().getInventory().removeItem(itemId, amount)){
+            if (!quest.getOwner().getInventory().removeItemById(itemId, amount)) {
                 success = false;
             }
         }


### PR DESCRIPTION
+[Bugfix] removeItem -> removeItemById
+[Refactor] clean up removeItem() functions

## Description
When starting quest 2001903, it ought to remove item 100302 using a QUEST_EXEC_DEL_ALL_SPECIFIC_PACK_ITEM:
![image](https://github.com/user-attachments/assets/6e6f7ee8-4c06-4c27-ab5e-d3f219003431)

if not removed, this item causes the quest to instafinish.


Also included on this PR:
`ExecDelPackItem` and `ExecDelPackItemBatch` were using `removeItem` instead of `removeItemById`
removeItem uses guids, which are not the same thing as itemIds.
see https://github.com/Grasscutters/Grasscutter/commit/13f055035fc3584eb527c1f73148953103cdb392

Removed the null check out of `removeItem(long guid, int count)`. 
This null check happens immediately in `removeItem(GameItem item, int count)`

`removeItem(long guid)` now removes every item instead of one item in order to mach the other variations of this function. 
The single use of this function has been looked at and ought to not cause problems.

`removeItems` now uses a lambda expression to make it more compact.


## Issues fixed by this PR
all better:
![image](https://github.com/user-attachments/assets/955fc917-c85d-4dc4-87a2-04a58b8d2790)



<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.