### PR TITLE
[Feature] QUEST EXEC UPDATE PARENT QUEST REWARD INDEX

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -25,12 +25,13 @@ import emu.grasscutter.server.packet.send.PacketQuestUpdateQuestVarNotify;
 import emu.grasscutter.utils.Position;
 import emu.grasscutter.utils.Utils;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.val;
 import org.anime_game_servers.core.gi.enums.QuestState;
+import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ChildQuest;
+import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ParentQuest;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
-import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ParentQuest;
-import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ChildQuest;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -51,7 +52,7 @@ public class GameMainQuest {
     @Getter private ParentQuestState state;
     @Getter private boolean isFinished;
     @Getter List<QuestGroupSuite> questGroupSuites;
-
+    @Getter @Setter private int rewardIndex = 0;
     @Getter int[] suggestTrackMainQuestList;
     @Getter private Map<Integer,TalkData> talks;
 
@@ -206,13 +207,9 @@ public class GameMainQuest {
         // Add rewards
         val mainQuestData = getMainQuestData();
         if(mainQuestData!= null && mainQuestData.getRewardIdList()!=null) {
-            for (int rewardId : mainQuestData.getRewardIdList()) {
-                RewardData rewardData = GameData.getRewardDataMap().get(rewardId);
-
-                if (rewardData == null) {
-                    continue;
-                }
-
+            int rewardId = mainQuestData.getRewardIdList()[rewardIndex];
+            RewardData rewardData = GameData.getRewardDataMap().get(rewardId);
+            if (rewardData != null) {
                 getOwner().getInventory().addItemParamDatas(rewardData.getRewardItemList(), ActionReason.QuestReward);
             }
         }

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -25,7 +25,6 @@ import emu.grasscutter.server.packet.send.PacketQuestUpdateQuestVarNotify;
 import emu.grasscutter.utils.Position;
 import emu.grasscutter.utils.Utils;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.val;
 import org.anime_game_servers.core.gi.enums.QuestState;
 import org.anime_game_servers.multi_proto.gi.messages.quest.parent.ChildQuest;
@@ -52,7 +51,7 @@ public class GameMainQuest {
     @Getter private ParentQuestState state;
     @Getter private boolean isFinished;
     @Getter List<QuestGroupSuite> questGroupSuites;
-    @Getter @Setter private int rewardIndex = 0;
+    @Getter private int rewardIndex = 0;
     @Getter int[] suggestTrackMainQuestList;
     @Getter private Map<Integer,TalkData> talks;
 
@@ -206,7 +205,7 @@ public class GameMainQuest {
 
         // Add rewards
         val mainQuestData = getMainQuestData();
-        if(mainQuestData!= null && mainQuestData.getRewardIdList()!=null) {
+        if (mainQuestData != null && mainQuestData.getRewardIdList() != null && mainQuestData.getRewardIdList().length > rewardIndex) {
             int rewardId = mainQuestData.getRewardIdList()[rewardIndex];
             RewardData rewardData = GameData.getRewardDataMap().get(rewardId);
             if (rewardData != null) {
@@ -498,5 +497,11 @@ public class GameMainQuest {
         }
 
         return owner.getWorld().getTotalGameTimeDays() - World.getHoursForGameTime(varTime);
+    }
+
+    public boolean setRewardIndex(int index) {
+        this.rewardIndex = index;
+        this.save();
+        return true;
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -41,7 +41,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_ROLLBACK_PARENT_QUEST (30),
     QUEST_EXEC_LOCK_AVATAR_TEAM (31),                       //#Missing
     QUEST_EXEC_UNLOCK_AVATAR_TEAM (32),                     //#Missing
-    QUEST_EXEC_UPDATE_PARENT_QUEST_REWARD_INDEX (33),       //#Missing
+    QUEST_EXEC_UPDATE_PARENT_QUEST_REWARD_INDEX (33),
     QUEST_EXEC_SET_DAILY_TASK_VAR (34),                     //#Missing
     QUEST_EXEC_INC_DAILY_TASK_VAR (35),                     //#Missing
     QUEST_EXEC_DEC_DAILY_TASK_VAR (36),                     //#Missing #Unused

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecUpdateParentQuestRewardIndex.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecUpdateParentQuestRewardIndex.java
@@ -1,0 +1,17 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.common.quest.SubQuestData.QuestExecParam;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_UPDATE_PARENT_QUEST_REWARD_INDEX)
+public class ExecUpdateParentQuestRewardIndex extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
+        int rewardIndex = Integer.parseInt(paramStr[0]);
+        quest.getMainQuest().setRewardIndex(rewardIndex);
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecUpdateParentQuestRewardIndex.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecUpdateParentQuestRewardIndex.java
@@ -11,7 +11,6 @@ public class ExecUpdateParentQuestRewardIndex extends QuestExecHandler {
     @Override
     public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
         int rewardIndex = Integer.parseInt(paramStr[0]);
-        quest.getMainQuest().setRewardIndex(rewardIndex);
-        return true;
+        return quest.getMainQuest().setRewardIndex(rewardIndex);
     }
 }


### PR DESCRIPTION
## Description
QUEST_EXEC_UPDATE_PARENT_QUEST_REWARD_INDEX sets which reward happens at the end of a main quest.
Before, you would get every possible reward:
![image](https://github.com/user-attachments/assets/46bac1c9-dc21-4830-add0-5e8ab6ada38a)

After, you now get one reward (default 0):
![image](https://github.com/user-attachments/assets/598720f7-d004-4eb0-befd-ca8b26c48637)

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.