### PR TITLE
[Feature] QUEST EXEC CHANGE SKILL DEPOT

### DIFF
--- a/src/main/java/emu/grasscutter/game/avatar/Avatar.java
+++ b/src/main/java/emu/grasscutter/game/avatar/Avatar.java
@@ -1,24 +1,6 @@
 package emu.grasscutter.game.avatar;
 
 import dev.morphia.annotations.*;
-import static emu.grasscutter.config.Configuration.GAME_OPTIONS;
-import static emu.grasscutter.game.props.PlayerProperty.PROP_SATIATION_PENALTY_TIME;
-import static emu.grasscutter.game.props.PlayerProperty.PROP_SATIATION_VAL;
-
-import java.util.*;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
-import lombok.*;
-import org.anime_game_servers.multi_proto.gi.messages.general.PropValue;
-import org.anime_game_servers.multi_proto.gi.messages.general.avatar.*;
-import org.anime_game_servers.multi_proto.gi.messages.general.avatar.FetterData;
-import org.bson.types.ObjectId;
-
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.OpenConfigEntry;
 import emu.grasscutter.data.binout.OpenConfigEntry.SkillPointModifier;
@@ -29,16 +11,33 @@ import emu.grasscutter.data.excels.ItemData.WeaponProperty;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.entity.EntityWeapon;
+import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
 import emu.grasscutter.game.inventory.EquipType;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.ItemType;
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.game.props.*;
+import emu.grasscutter.game.props.ElementType;
+import emu.grasscutter.game.props.FetterState;
+import emu.grasscutter.game.props.FightProperty;
+import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.server.packet.send.*;
 import emu.grasscutter.utils.ProtoHelper;
 import it.unimi.dsi.fastutil.ints.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.val;
+import org.anime_game_servers.multi_proto.gi.messages.general.PropValue;
+import org.anime_game_servers.multi_proto.gi.messages.general.avatar.*;
+import org.anime_game_servers.multi_proto.gi.messages.general.avatar.FetterData;
+import org.bson.types.ObjectId;
 
 import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static emu.grasscutter.config.Configuration.GAME_OPTIONS;
+import static emu.grasscutter.game.props.PlayerProperty.PROP_SATIATION_VAL;
 
 @Entity(value = "avatars", useDiscriminator = false)
 public class Avatar {
@@ -214,8 +213,12 @@ public class Avatar {
      * @return false if failed or already using that element, true if it actually changed
      */
     public boolean changeElement(@Nonnull ElementType elementTypeToChange) {
-        val candSkillDepotIdsList = data.getCandSkillDepotIds();
         val candSkillDepotIndex = elementTypeToChange.getDepotIndex();
+        return changeSkillDepot(candSkillDepotIndex);
+    }
+
+    public boolean changeSkillDepot(int candSkillDepotIndex) {
+        val candSkillDepotIdsList = data.getCandSkillDepotIds();
 
         // if no candidate skill to change or index out of bound
         if (candSkillDepotIdsList == null || candSkillDepotIndex >= candSkillDepotIdsList.size()) {

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -62,7 +62,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_ACTIVATE_SCANNING_PIC (52),                  //#Missing #Unused
     QUEST_EXEC_RELOAD_SCENE_TAG (53),                       //#Missing
     QUEST_EXEC_REGISTER_DYNAMIC_GROUP_ONLY (54),            //#Missing
-    QUEST_EXEC_CHANGE_SKILL_DEPOT (55),                     //#Missing
+    QUEST_EXEC_CHANGE_SKILL_DEPOT (55),
     QUEST_EXEC_ADD_SCENE_TAG (56),
     QUEST_EXEC_DEL_SCENE_TAG (57),
     QUEST_EXEC_INIT_TIME_VAR (58),

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecChangeSkillDepot.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecChangeSkillDepot.java
@@ -1,0 +1,30 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.common.quest.SubQuestData.QuestExecParam;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestSystem;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import lombok.val;
+
+/**
+ * Changes the main avatar's element. First parameter is the skill depot index
+ */
+@QuestValueExec(QuestExec.QUEST_EXEC_CHANGE_SKILL_DEPOT)
+public class ExecChangeSkillDepot extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestExecParam condition, String... paramStr) {
+        val targetSkillDepotIndex = Integer.parseInt(paramStr[0]);
+        val owner = quest.getOwner();
+        val mainAvatar = owner.getAvatars().getAvatarById(owner.getMainCharacterId());
+
+        if (mainAvatar == null) {
+            QuestSystem.getLogger().error("Failed to get main avatar for use {}", quest.getOwner().getUid());
+            return false;
+        }
+
+        QuestSystem.getLogger().info("Changing avatar skill depot index to {} for quest {}", targetSkillDepotIndex, quest.getSubQuestId());
+        return mainAvatar.changeSkillDepot(targetSkillDepotIndex);
+    }
+}


### PR DESCRIPTION
## Description
During quest 200102, it is supposed to take your element away. We didn't have that implemented:
![image](https://github.com/user-attachments/assets/edfbebef-5025-467e-bcd5-4205d7c6a1b7)

Now it's in:
![image](https://github.com/user-attachments/assets/95b5b7ed-be0c-4620-b017-dcfb05299920)

To do this, `changeElement` was split into `changeElement` and `changeSkillDepot`
See QUEST_EXEC_CHANGE_AVATAR_ELEMET (sic) for changing the avatar element by element Id (only used in first starting quest to give you the element when touching the statue for the first time)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.