### PR TITLE
[Feature] QUEST COND PLAYER ENTER REGION

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPlayerEnterRegion.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPlayerEnterRegion.java
@@ -1,0 +1,26 @@
+package emu.grasscutter.game.quest.conditions;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.common.quest.SubQuestData;
+import emu.grasscutter.data.common.quest.SubQuestData.QuestAcceptCondition;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
+
+import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_PLAYER_ENTER_REGION;
+
+@QuestValueCond(QUEST_COND_PLAYER_ENTER_REGION)
+public class ConditionPlayerEnterRegion extends BaseCondition {
+
+    @Override
+    public boolean execute(Player owner, SubQuestData questData, QuestAcceptCondition condition, String paramStr, int... params) {
+        if (condition.getParam().length < 2 || params.length != 2) {
+            Grasscutter.getLogger().error("Unexpected number of params on QUEST_COND_PLAYER_ENTER_REGION for quest {}", questData.getSubId());
+            return false;
+        }
+        val groupId = condition.getParam()[0]; //already checked
+        val configId = condition.getParam()[1];
+        return params[1] == configId;
+    }
+
+}

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
@@ -11,12 +11,12 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_NONE (0),
     QUEST_COND_STATE_EQUAL (1),
     QUEST_COND_STATE_NOT_EQUAL (2),
-    QUEST_COND_PACK_HAVE_ITEM (3),
+    QUEST_COND_PACK_HAVE_ITEM (3),                  //#Missing the trigger
     QUEST_COND_AVATAR_ELEMENT_EQUAL (4),            //#Missing #NpcGroup #TalkExcel
     QUEST_COND_AVATAR_ELEMENT_NOT_EQUAL (5),        //#Missing #NpcGroup #TalkExcel
     QUEST_COND_AVATAR_CAN_CHANGE_ELEMENT (6),       //#Missing #NpcGroup #TalkExcel
     QUEST_COND_CITY_LEVEL_EQUAL_GREATER (7),        //#Missing #QuestTalks #TalkExcel
-    QUEST_COND_ITEM_NUM_LESS_THAN (8),
+    QUEST_COND_ITEM_NUM_LESS_THAN (8),              //#Missing the trigger
     QUEST_COND_DAILY_TASK_START (9),                //#Missing #QuestExcel
     QUEST_COND_OPEN_STATE_EQUAL (10),
     QUEST_COND_DAILY_TASK_OPEN (11),                //#Missing #NpcGroup #TalkExcel
@@ -39,7 +39,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_DAILY_TASK_IN_PROGRESS (28),         //#Missing #QuestTalks #TalkExcel
     QUEST_COND_DAILY_TASK_FINISHED (29),            //#Missing #Unused
     QUEST_COND_ACTIVITY_COND (30),
-    QUEST_COND_ACTIVITY_OPEN (31),
+    QUEST_COND_ACTIVITY_OPEN (31),                  //#Missing the trigger
     QUEST_COND_DAILY_TASK_VAR_GT (32),              //#Missing #QuestExcel #QuestTalks #TalkExcel
     QUEST_COND_DAILY_TASK_VAR_EQ (33),              //#Missing #QuestExcel #QuestTalks #NpcGroup #TalkExcel
     QUEST_COND_DAILY_TASK_VAR_LT (34),              //#Missing #QuestExcel #QuestTalks #TalkExcel
@@ -63,7 +63,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_CITY_REPUTATION_UNLOCK (52),         //#Missing #Unused
     QUEST_COND_LUA_NOTIFY (53),
     QUEST_COND_CUR_CLIMATE (54),                    //#Missing #QuestExcel
-    QUEST_COND_ACTIVITY_END (55),
+    QUEST_COND_ACTIVITY_END (55),                   //#Missing the trigger
     QUEST_COND_COOP_POINT_RUNNING (56),             //#Missing #Unused
     QUEST_COND_GADGET_TALK_STATE_EQUAL (57),        //#Missing #QuestTalks #GadgetGroup #NpcGroup #TalkExcel
     QUEST_COND_AVATAR_FETTER_GT (58),               //#Missing #QuestTalks #NpcGroup #TalkExcel
@@ -86,7 +86,7 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_NEW_HOMEWORLD_SHOP_ITEM (75),        //#Missing #GadgetGroup #TalkExcel
     QUEST_COND_SCENE_POINT_UNLOCK (76),             //#Missing #NpcGroup #TalkExcel
     QUEST_COND_SCENE_LEVEL_TAG_EQ (77),
-    QUEST_COND_PLAYER_ENTER_REGION (78),            //#Missing #QuestExcel
+    QUEST_COND_PLAYER_ENTER_REGION (78),
     QUEST_COND_UNKNOWN (9999);
 
     private final int value;

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestContent.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestContent.java
@@ -12,11 +12,11 @@ public enum QuestContent implements QuestTrigger {
     QUEST_CONTENT_KILL_MONSTER (1),                         //#Unused
     QUEST_CONTENT_COMPLETE_TALK (2),
     QUEST_CONTENT_MONSTER_DIE (3),
-    QUEST_CONTENT_FINISH_PLOT (4),
+    QUEST_CONTENT_FINISH_PLOT (4),                          //gets sent by AddQuestContentProgressReq
     QUEST_CONTENT_OBTAIN_ITEM (5),
     QUEST_CONTENT_TRIGGER_FIRE (6),
     QUEST_CONTENT_CLEAR_GROUP_MONSTER (7),
-    QUEST_CONTENT_NOT_FINISH_PLOT (8),                      //#Missing the trigger #RandomQuestExcel
+    QUEST_CONTENT_NOT_FINISH_PLOT (8),                      //gets sent by AddQuestContentProgressReq
     QUEST_CONTENT_ENTER_DUNGEON (9),
     QUEST_CONTENT_ENTER_MY_WORLD (10),
     QUEST_CONTENT_FINISH_DUNGEON (11),

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -13,6 +13,7 @@ import emu.grasscutter.game.entity.create_config.CreateNpcEntityConfig;
 import emu.grasscutter.game.entity.create_config.CreateRegionEntityConfig;
 import emu.grasscutter.game.quest.GameQuest;
 import emu.grasscutter.game.quest.QuestGroupSuite;
+import emu.grasscutter.game.quest.enums.QuestCond;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.game.world.SceneGroupInstance;
@@ -604,6 +605,9 @@ public class SceneScriptManager {
             .setSourceEntityId(region.getId())
             .setTargetEntityId(entity.getId())
         );
+        if (eventType == EventType.EVENT_ENTER_REGION && entity instanceof EntityAvatar avatar) {
+            avatar.getPlayer().getQuestManager().queueEvent(QuestCond.QUEST_COND_PLAYER_ENTER_REGION, region.getGroupId(), region.getConfigId());
+        }
     }
 
     public List<EntityGadget> getGadgetsInGroupSuite(SceneGroupInstance groupInstance, SceneSuite suite) {


### PR DESCRIPTION
## Description
Some quests start when you enter a region defined in a group.
We did not have that implemented:
![image](https://github.com/user-attachments/assets/7a7aace4-893b-4635-85bf-703211f449aa)

Now it is:
![image](https://github.com/user-attachments/assets/1626a3ab-c38f-4ead-9f0f-90284f98ca6b)


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [x] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.