### PR TITLE
[Feature] QUEST CONTENT GADGET STATE CHANGE

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityBaseGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityBaseGadget.java
@@ -8,7 +8,6 @@ import emu.grasscutter.game.entity.create_config.CreateGadgetEntityConfig;
 import emu.grasscutter.game.entity.gadget.content.GadgetContent;
 import emu.grasscutter.game.entity.interfaces.ConfigAbilityDataAbilityEntity;
 import emu.grasscutter.game.player.Player;
-import emu.grasscutter.game.props.EntityIdType;
 import emu.grasscutter.game.props.FightProperty;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.game.world.Scene;
@@ -24,7 +23,6 @@ import org.anime_game_servers.multi_proto.gi.messages.gadget.GadgetInteractReq;
 import org.anime_game_servers.multi_proto.gi.messages.scene.VisionType;
 
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -188,5 +186,10 @@ public abstract class EntityBaseGadget extends GameEntity<CreateGadgetEntityConf
             .setParam2(this.getConfigId())
             .setParam3(oldState)
             .setSourceEntityId(getId()));
+        getScene().getPlayers().forEach(player ->
+                player.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_GADGET_STATE_CHANGE,
+                        String.valueOf(state),
+                        this.getGroupId(),
+                        this.getConfigId()));
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentGadgetStateChange.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentGadgetStateChange.java
@@ -1,0 +1,24 @@
+package emu.grasscutter.game.quest.content;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.common.quest.SubQuestData;
+import emu.grasscutter.data.common.quest.SubQuestData.QuestContentCondition;
+import emu.grasscutter.game.quest.QuestValueContent;
+import emu.grasscutter.game.quest.enums.QuestContent;
+import lombok.val;
+
+@QuestValueContent(QuestContent.QUEST_CONTENT_GADGET_STATE_CHANGE)
+public class ContentGadgetStateChange extends BaseContent {
+    @Override
+    public boolean isEvent(SubQuestData questData, QuestContentCondition condition, QuestContent type, String paramStr, int... params) {
+        if (condition.getParam().length < 2 || params.length != 2) {
+            Grasscutter.getLogger().error("Unexpected number of params on QUEST_CONTENT_GADGET_STATE_CHANGE for quest {}", questData.getSubId());
+            return false;
+        }
+        val groupId = condition.getParam()[0];
+        val configId = condition.getParam()[1];
+        val gadgetState = condition.getParamString();
+
+        return groupId == params[0] && configId == params[1] && paramStr.equals(gadgetState);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestContent.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestContent.java
@@ -82,7 +82,7 @@ public enum QuestContent implements QuestTrigger {
     QUEST_CONTENT_IRODORI_POETRY_REACH_MIN_PROGRESS (152),  //#Missing
     QUEST_CONTENT_IRODORI_POETRY_FINISH_FILL_POETRY (153),  //#Missing
     QUEST_CONTENT_ACTIVITY_TRIGGER_UPDATE (154),            //#Missing
-    QUEST_CONTENT_GADGET_STATE_CHANGE (155),                //#Missing
+    QUEST_CONTENT_GADGET_STATE_CHANGE (155),
     QUEST_CONTENT_UNKNOWN (9999);
 
     private final int value;


### PR DESCRIPTION
## Description
QUEST_CONTENT_GADGET_STATE_CHANGE is triggered when a gadget changes state.

Before, this quest got stuck at "Go to the kitchen"
It depends on a gadget that changes state to GadgetState.GearStart when you enter a region (see group 133104832)
![image](https://github.com/user-attachments/assets/10537bfe-ddfc-4fba-a70e-384d6b06794b)

But now it works as intended:
![image](https://github.com/user-attachments/assets/024af5c0-cdfe-401a-9a94-420c49c903d1)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.