### PR TITLE
[Refactoring] Quest conditions are not done by checking params[]

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/giving/GivingManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/giving/GivingManager.java
@@ -97,6 +97,48 @@ public class GivingManager extends BasePlayerDataManager {
     }
 
     /**
+     * Checks if a giving action is marked completed.
+     *
+     * @param givingId The giving action ID.
+     */
+    public boolean isCompleted(int givingId) {
+        if (!this.itemGivings.containsKey(givingId)) {
+            return false;
+        }
+        return this.itemGivings.get(givingId).isFinished();
+    }
+
+    /**
+     * Gets the last GroupId.
+     *
+     * @param givingId The giving action ID.
+     */
+    @Nullable
+    public Integer getLastGroupId(int givingId) {
+        if (!this.itemGivings.containsKey(givingId)) {
+            return null;
+        }
+        return this.itemGivings.get(givingId).getLastGroupId();
+    }
+
+
+    /**
+     * Set the last groupId for a giving action.
+     *
+     * @param givingId The giving action ID.
+     * @param groupId  The last groupId.
+     */
+    public void setLastGroupId(int givingId, int groupId) throws IllegalStateException {
+        // Check if the action is already present.
+        if (!this.itemGivings.containsKey(givingId)) {
+            throw new IllegalStateException("Giving action " + givingId + " is not active.");
+        }
+
+        // Mark the action as finished.
+        this.itemGivings.get(givingId).setLastGroupId(groupId);
+    }
+
+    /**
      * Attempts to add the giving action.
      *
      * @param givingId The giving action ID.
@@ -111,16 +153,6 @@ public class GivingManager extends BasePlayerDataManager {
         this.sendGivingRecordNotify();
         return success == null;
     }
-
-    /**
-     * Checks if itemGivings contains the key.
-     *
-     * @param givingId The giving action ID.
-     */
-    public boolean containsGiveItemAction(int givingId) {
-        return this.itemGivings.containsKey(givingId);
-    }
-
 
     /**
      * Verifies, performs and notifies a requested giving action.
@@ -155,6 +187,8 @@ public class GivingManager extends BasePlayerDataManager {
         // Send the response packet.
         player.sendPacket(new PacketItemGivingRsp(result));
         if(result.isSuccess()) {
+            //store last GroupId.
+            setLastGroupId(result.givingId, result.givingGroupId);
             // Mark the giving action as completed.
             markCompleted(giveId);
 
@@ -175,7 +209,7 @@ public class GivingManager extends BasePlayerDataManager {
      */
     @Nullable
     public GivingData checkAndGetGivingData(int giveId){
-        if (!containsGiveItemAction(giveId)) return null;
+        if (!this.itemGivings.containsKey(giveId)) return null;
 
         // Check the items against the resources.
         var data = GameData.getGivingDataMap().get(giveId);

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionItemGivingFinished.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionItemGivingFinished.java
@@ -4,6 +4,7 @@ import emu.grasscutter.data.common.quest.SubQuestData;
 import emu.grasscutter.data.common.quest.SubQuestData.QuestAcceptCondition;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.quest.QuestValueCond;
+import lombok.val;
 
 import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ITEM_GIVING_FINISHED;
 
@@ -11,6 +12,15 @@ import static emu.grasscutter.game.quest.enums.QuestCond.QUEST_COND_ITEM_GIVING_
 public class ConditionItemGivingFinished extends BaseCondition {
     @Override
     public boolean execute(Player owner, SubQuestData questData, QuestAcceptCondition condition, String paramStr, int... params) {
-        return condition.getParam()[0] == params[0] && (condition.getParam()[1] == 0 || condition.getParam()[1] == params[1]);
+        val givingId = condition.getParam()[0];
+        val givingGroupId = condition.getParam()[0];
+
+        if (owner.getGivingManager().isCompleted(givingId)) {
+            if (givingGroupId == 0) return true;
+            val lastGroupId = owner.getGivingManager().getLastGroupId(givingId);
+            if (lastGroupId == null) return false;
+            return givingGroupId == lastGroupId;
+        }
+        return false;
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPlayerEnterRegion.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPlayerEnterRegion.java
@@ -3,7 +3,9 @@ package emu.grasscutter.game.quest.conditions;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.common.quest.SubQuestData;
 import emu.grasscutter.data.common.quest.SubQuestData.QuestAcceptCondition;
+import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.props.EntityType;
 import emu.grasscutter.game.quest.QuestValueCond;
 import lombok.val;
 
@@ -14,13 +16,26 @@ public class ConditionPlayerEnterRegion extends BaseCondition {
 
     @Override
     public boolean execute(Player owner, SubQuestData questData, QuestAcceptCondition condition, String paramStr, int... params) {
-        if (condition.getParam().length < 2 || params.length != 2) {
+        if (condition.getParam().length < 2) {
             Grasscutter.getLogger().error("Unexpected number of params on QUEST_COND_PLAYER_ENTER_REGION for quest {}", questData.getSubId());
             return false;
         }
         val groupId = condition.getParam()[0];
         val configId = condition.getParam()[1];
-        return params[0] == groupId && params[1] == configId;
+        val entityRegion = owner.getScene().getScriptManager().getRegionByConfigId(configId, groupId);
+
+        if (entityRegion == null) {
+            Grasscutter.getLogger().error("Could not find region with configId {} for quest {}", configId, questData.getSubId());
+            return false;
+        }
+
+        val players = entityRegion.getEntities().stream().filter(e -> e.getEntityType() == EntityType.Avatar).toList();
+        for (val player : players) {
+            if (player instanceof EntityAvatar avatar && avatar.getPlayer().getUid() == owner.getUid()) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -330,6 +330,14 @@ public class SceneScriptManager {
 
         return true;
     }
+
+    public EntityRegion getRegionByConfigId(int configId, int groupId) {
+        return this.regions.values().stream()
+            .filter(x -> x.getConfigId() == configId && x.getGroupId() == groupId)
+            .findFirst()
+            .orElse(null);
+    }
+
     public EntityRegion getRegionById(int id) {
         return regions.get(id);
     }


### PR DESCRIPTION
## Description
I forgot, but QUEST_COND are checked against the current game state. They are not checked against params[].

Both of these have been lightly tested as working.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.