### PR TITLE
[Feature] Triggers for PACK_HAVE_ITEM and ITEM_NUM_LESS_THAN

### DIFF
--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -13,6 +13,7 @@ import emu.grasscutter.game.props.ActionReason;
 import emu.grasscutter.game.props.ItemUseAction.UseItemParams;
 import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.game.props.WatcherTriggerType;
+import emu.grasscutter.game.quest.enums.QuestCond;
 import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.server.packet.send.*;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -241,10 +242,12 @@ public class Inventory extends BasePlayerManager implements Iterable<GameItem> {
         getPlayer().getBattlePassManager().triggerMission(WatcherTriggerType.TRIGGER_OBTAIN_MATERIAL_NUM, result.getItemId(), result.getCount());
         getPlayer().getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_OBTAIN_ITEM, result.getItemId(), result.getCount());
         getPlayer().getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_OBTAIN_VARIOUS_ITEM, result.getItemId(), result.getCount());
+        getPlayer().getQuestManager().queueEvent(QuestCond.QUEST_COND_PACK_HAVE_ITEM, result.getItemId(), result.getCount());
     }
     private void triggerRemItemEvents(GameItem item, int removeCount){
         getPlayer().getBattlePassManager().triggerMission(WatcherTriggerType.TRIGGER_COST_MATERIAL, item.getItemId(), removeCount);
         getPlayer().getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_ITEM_LESS_THAN, item.getItemId(), item.getCount());
+        getPlayer().getQuestManager().queueEvent(QuestCond.QUEST_COND_ITEM_NUM_LESS_THAN, item.getItemId(), item.getCount());
     }
 
     public void addItemParams(Collection<ItemParam> items) {

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPackHaveItem.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionPackHaveItem.java
@@ -14,7 +14,9 @@ public class ConditionPackHaveItem extends BaseCondition {
     @Override
     public boolean execute(Player owner, SubQuestData questData, QuestAcceptCondition condition, String paramStr, int... params) {
         val itemId = condition.getParam()[0];
-        val targetAmount = condition.getParam()[1];
+        var targetAmount = 1;
+        if (condition.getParam().length > 1)
+            targetAmount = condition.getParam()[1];
         val itemCount = owner.getInventory().getItemCountById(itemId);
         return itemCount >= targetAmount;
     }

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestCond.java
@@ -11,12 +11,12 @@ public enum QuestCond implements QuestTrigger {
     QUEST_COND_NONE (0),
     QUEST_COND_STATE_EQUAL (1),
     QUEST_COND_STATE_NOT_EQUAL (2),
-    QUEST_COND_PACK_HAVE_ITEM (3),                  //#Missing the trigger
+    QUEST_COND_PACK_HAVE_ITEM (3),
     QUEST_COND_AVATAR_ELEMENT_EQUAL (4),            //#Missing #NpcGroup #TalkExcel
     QUEST_COND_AVATAR_ELEMENT_NOT_EQUAL (5),        //#Missing #NpcGroup #TalkExcel
     QUEST_COND_AVATAR_CAN_CHANGE_ELEMENT (6),       //#Missing #NpcGroup #TalkExcel
     QUEST_COND_CITY_LEVEL_EQUAL_GREATER (7),        //#Missing #QuestTalks #TalkExcel
-    QUEST_COND_ITEM_NUM_LESS_THAN (8),              //#Missing the trigger
+    QUEST_COND_ITEM_NUM_LESS_THAN (8),
     QUEST_COND_DAILY_TASK_START (9),                //#Missing #QuestExcel
     QUEST_COND_OPEN_STATE_EQUAL (10),
     QUEST_COND_DAILY_TASK_OPEN (11),                //#Missing #NpcGroup #TalkExcel


### PR DESCRIPTION
## Description
Somehow, PACK_HAVE_ITEM and ITEM_NUM_LESS_THAN don't have things that trigger them.

This is important for quest 7218301: The Art of Horticulture
This quest is started only after obtaining the quest variant of [Naku Weed Seed](https://genshin-impact.fandom.com/wiki/Naku_Weed_Seed_(Quest_Item))

With these changes, the quest has started when I give myself that item:
![image](https://github.com/user-attachments/assets/cbc66f18-04d0-4d6f-aee5-617cf8b0d6fd)



## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.