### PR TITLE
Fix display EXP when Adventure Rank goes up

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1568,7 +1568,6 @@ public class Player {
         if (sendPacket) {
             // Update player with packet
             this.sendPacket(new PacketPlayerPropNotify(this, prop));
-            this.sendPacket(new PacketPlayerPropChangeNotify(this, prop, value - currentValue));
 
             if (prop == PlayerProperty.PROP_MAX_STAMINA) {
                 this.sendPacket(new PacketPlayerPropChangeReasonNotify(this, prop, currentValue, value, PropChangeReason.PROP_CHANGE_CITY_LEVELUP));

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1566,7 +1566,7 @@ public class Player {
         int currentValue = this.properties.get(prop.getId());
         this.properties.put(prop.getId(), value);
         if (sendPacket) {
-            // Update player with packet
+            // Notify the client about the player property change. For cb1 clients we probably need to send PlayerPropChangeNotify instead. TODO: verify
             this.sendPacket(new PacketPlayerPropNotify(this, prop));
 
             if (prop == PlayerProperty.PROP_MAX_STAMINA) {

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -604,11 +604,11 @@ public class Player {
 
     // Directly give player exp
     public void addExpDirectly(int gain) {
+        int currentExp = getExp();
+        int exp = currentExp + gain;
         int level = getLevel();
-        int exp = getExp();
         int reqExp = getExpRequired(level);
-
-        exp += gain;
+        var changeReason = PropChangeReason.PROP_CHANGE_PLAYER_ADD_EXP;
 
         while (exp >= reqExp && reqExp > 0) {
             exp -= reqExp;
@@ -616,11 +616,17 @@ public class Player {
             reqExp = getExpRequired(level);
 
             // Set level each time to allow level-up specific logic to run.
-            this.setLevel(level);
+            if (!this.setLevel(level)) return;
+
+            // This ensures the number of gained exp is correct (when exp < currentExp)
+            this.sendPacket(new PacketPlayerPropChangeReasonNotify(this, PlayerProperty.PROP_PLAYER_LEVEL, level-1, level, changeReason));
+            changeReason = PropChangeReason.PROP_CHANGE_AVATAR_UPGRADE;
         }
 
         // Set exp
-        this.setProperty(PlayerProperty.PROP_PLAYER_EXP, exp);
+        if (this.setProperty(PlayerProperty.PROP_PLAYER_EXP, exp)) {
+            this.sendPacket(new PacketPlayerPropChangeReasonNotify(this, PlayerProperty.PROP_PLAYER_EXP, currentExp, exp, changeReason));
+        }
     }
 
     private void updateWorldLevel() {
@@ -1564,10 +1570,7 @@ public class Player {
             this.sendPacket(new PacketPlayerPropNotify(this, prop));
             this.sendPacket(new PacketPlayerPropChangeNotify(this, prop, value - currentValue));
 
-            // Make the Adventure EXP pop-up show on screen.
-            if (prop == PlayerProperty.PROP_PLAYER_EXP) {
-                this.sendPacket(new PacketPlayerPropChangeReasonNotify(this, prop, currentValue, value, PropChangeReason.PROP_CHANGE_PLAYER_ADD_EXP));
-            } else if(prop == PlayerProperty.PROP_MAX_STAMINA) {
+            if (prop == PlayerProperty.PROP_MAX_STAMINA) {
                 this.sendPacket(new PacketPlayerPropChangeReasonNotify(this, prop, currentValue, value, PropChangeReason.PROP_CHANGE_CITY_LEVELUP));
             }
         }


### PR DESCRIPTION
## Description

Currently, we have the following packets sent:
- PlayerPropNotify (level up)
- PlayerPropChangeNotify (level up)
- PlayerPropNotify (exp)
- PlayerPropChangeNotify (exp)
- PlayerPropChangeReasonNotify (exp, PROP_CHANGE_REASON_PLAYER_ADD_EXP)

The correct packet order should be:
- PlayerPropNotify (level up)
- PlayerPropChangeReasonNotify (level up, PROP_CHANGE_REASON_PLAYER_ADD_EXP)
- PlayerPropNotify (exp)
- PlayerPropChangeReasonNotify (exp, PROP_CHANGE_REASON_AVATAR_UPGRADE)

I also checked v3.2, `PlayerPropChangeNotify` (cmd 139) doesn't show up anywhere, seems like PlayerPropNotify is enough.
v5.7 also doesn't make use of that. So sending it for "delta" in GC (sometimes negative like this) is unnecessary

<img width="390" height="110" alt="image" src="https://github.com/user-attachments/assets/4deda444-3b33-4773-8099-22a92e46436f" />


## Issues fixed by this PR
Fix #200 


https://github.com/user-attachments/assets/83690502-ea59-4d0d-a4f9-cc4f05fc6da9



<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.